### PR TITLE
Fix labels in columns from slug

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import _sortBy from 'lodash/sortBy';
 import reverse from 'lodash/reverse';
+import capitalize from 'lodash/capitalize';
 import {
   Table as VirtualizedTable,
   Column,
@@ -125,6 +126,7 @@ class Table extends PureComponent {
     const columnData = activeColumnNames
       .filter(c => firstColumnHeaders.includes(c))
       .concat(difference(activeColumnNames, firstColumnHeaders));
+    const columnLabel = columnSlug => capitalize(columnSlug.replace(/_/g, ' '));
     return (
       <div className={cx({ [styles.hasColumnSelect]: hasColumnSelect })}>
         {
@@ -176,7 +178,7 @@ class Table extends PureComponent {
                         ellipsisColumns.indexOf(column) > -1
                     })}
                     key={column}
-                    label={column}
+                    label={columnLabel(column)}
                     dataKey={column}
                     width={setColumnWidth(column)}
                     flexGrow={1}


### PR DESCRIPTION
This little PR fixes the labels on the table columns. The new labels have the _ removed and are capitalized

![image](https://user-images.githubusercontent.com/9701591/45154984-b22b4580-b1d9-11e8-821c-917e6fec9f19.png)
