### PR TITLE
Allow passing callback to charts to format Y labels

### DIFF
--- a/src/components/charts/bar-chart/axis-ticks.js
+++ b/src/components/charts/bar-chart/axis-ticks.js
@@ -20,26 +20,34 @@ export const CustomXAxisTick = ({ x, y, payload }) => (
 
 const getYLabelformat = value => `${format(`.0s`)(value)}`;
 
-export const CustomYAxisTick = ({ index, x, y, payload }) => (
-  <g transform={`translate(${x},${y})`}>
-    <text
-      x="0"
-      y="0"
-      dy="0"
-      textAnchor="end"
-      stroke="#b1b1c1"
-      strokeWidth="0.5"
-      fontSize="13px"
-    >
-      {
-        index === 0 &&
-          (payload.value === 0 || payload.value < 0 && payload.value > -0.001)
-          ? '0'
-          : getYLabelformat(payload.value)
-      }
-    </text>
-  </g>
-);
+export const CustomYAxisTick = (
+  { index, x, y, payload, getCustomYLabelFormat }
+) =>
+  {
+    const yLabelFormat = value =>
+      yLabelFormat ? getCustomYLabelFormat(value) : getYLabelformat(value);
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <text
+          x="0"
+          y="0"
+          dy="0"
+          textAnchor="end"
+          stroke="#b1b1c1"
+          strokeWidth="0.5"
+          fontSize="13px"
+        >
+          {
+            index === 0 &&
+              (payload.value === 0 ||
+                payload.value < 0 && payload.value > -0.001)
+              ? '0'
+              : yLabelFormat(payload.value)
+          }
+        </text>
+      </g>
+    );
+  };
 
 CustomXAxisTick.propTypes = {
   x: PropTypes.number,
@@ -53,9 +61,16 @@ CustomYAxisTick.propTypes = {
   x: PropTypes.number,
   y: PropTypes.number,
   index: PropTypes.number,
-  payload: PropTypes.object
+  payload: PropTypes.object,
+  getCustomYLabelFormat: PropTypes.func
 };
 
-CustomYAxisTick.defaultProps = { x: null, y: null, index: null, payload: {} };
+CustomYAxisTick.defaultProps = {
+  x: null,
+  y: null,
+  index: null,
+  payload: {},
+  getCustomYLabelFormat: null
+};
 
 CustomYAxisTick.defaultProps = {};

--- a/src/components/charts/bar-chart/axis-ticks.js
+++ b/src/components/charts/bar-chart/axis-ticks.js
@@ -25,7 +25,9 @@ export const CustomYAxisTick = (
 ) =>
   {
     const yLabelFormat = value =>
-      yLabelFormat ? getCustomYLabelFormat(value) : getYLabelformat(value);
+      getCustomYLabelFormat
+        ? getCustomYLabelFormat(value)
+        : getYLabelformat(value);
     return (
       <g transform={`translate(${x},${y})`}>
         <text

--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -42,7 +42,8 @@ class SimpleBarChart extends PureComponent {
       forceFixedFormatDecimals,
       customXAxisTick,
       customYAxisTick,
-      customTooltip
+      customTooltip,
+      getCustomYLabelFormat
     } = this.props;
     const unit = showUnit &&
       config &&
@@ -89,7 +90,14 @@ class SimpleBarChart extends PureComponent {
               tickLine={false}
               scale="linear"
               type="number"
-              tick={customYAxisTick || <CustomYAxisTick />}
+              tick={
+                customYAxisTick ||
+                  (
+                    <CustomYAxisTick
+                      getCustomYLabelFormat={getCustomYLabelFormat}
+                    />
+                  )
+              }
               domain={domain && domain.y || [ 'auto', 'auto' ]}
               interval="preserveStartEnd"
             >
@@ -135,7 +143,8 @@ SimpleBarChart.propTypes = {
   domain: PropTypes.object,
   customXAxisTick: PropTypes.node,
   customYAxisTick: PropTypes.node,
-  customTooltip: PropTypes.node
+  customTooltip: PropTypes.node,
+  getCustomYLabelFormat: PropTypes.func
 };
 
 SimpleBarChart.defaultProps = {
@@ -150,7 +159,8 @@ SimpleBarChart.defaultProps = {
   data: [],
   customXAxisTick: null,
   customYAxisTick: null,
-  customTooltip: null
+  customTooltip: null,
+  getCustomYLabelFormat: null
 };
 
 export default SimpleBarChart;

--- a/src/components/charts/chart-composed/chart-composed.js
+++ b/src/components/charts/chart-composed/chart-composed.js
@@ -56,7 +56,8 @@ class ChartComposed extends PureComponent {
       areaAsBackgroundForCartesianGrid,
       customXAxisTick,
       customYAxisTick,
-      customTooltip
+      customTooltip,
+      getCustomYLabelFormat
     } = this.props;
     const unit = showUnit &&
       config &&
@@ -104,7 +105,13 @@ class ChartComposed extends PureComponent {
               type="number"
               tick={
                 customYAxisTick ||
-                  <CustomYAxisTick precision={config.precision} unit={unit} />
+                  (
+                    <CustomYAxisTick
+                      precision={config.precision}
+                      unit={unit}
+                      getCustomYLabelFormat={getCustomYLabelFormat}
+                    />
+                  )
               }
               domain={domain && domain.y || [ 'auto', 'auto' ]}
               interval="preserveStartEnd"
@@ -175,7 +182,9 @@ ChartComposed.propTypes = {
   /** Custom Y Axis Tick component to pass it down to chart */
   customYAxisTick: PropTypes.node,
   /** Custom tooltip to pass down to chart */
-  customTooltip: PropTypes.node
+  customTooltip: PropTypes.node,
+  /** Function transforming y axis value */
+  getCustomYLabelFormat: PropTypes.func
 };
 
 ChartComposed.defaultProps = {
@@ -197,7 +206,8 @@ ChartComposed.defaultProps = {
   areaAsBackgroundForCartesianGrid: null,
   customXAxisTick: null,
   customYAxisTick: null,
-  customTooltip: null
+  customTooltip: null,
+  getCustomYLabelFormat: null
 };
 
 export default ChartComposed;

--- a/src/components/charts/chart/chart.js
+++ b/src/components/charts/chart/chart.js
@@ -116,7 +116,9 @@ Chart.propTypes = {
   /** Custom Y Axis Tick component to pass it down to chart */
   customYAxisTick: PropTypes.node,
   /** Custom tooltip to pass down to chart */
-  customTooltip: PropTypes.node
+  customTooltip: PropTypes.node,
+  /** Function transforming y axis value */
+  getCustomYLabelFormat: PropTypes.func
 };
 
 Chart.defaultProps = {
@@ -134,7 +136,8 @@ Chart.defaultProps = {
   lineType: 'monotone',
   customXAxisTick: null,
   customYAxisTick: null,
-  customTooltip: null
+  customTooltip: null,
+  getCustomYLabelFormat: null
 };
 
 export default Chart;

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -80,14 +80,16 @@ const toggleCharType = (filtersSelected) => {
 </React.Fragment>
 ```
 
-Example with bar chart
+Example with bar chart and passing callback formatting y axis labels
 ```js
 const data = require('../bar-chart/data.js');
+const format = require('d3-format').format;
 initialState = {
   ...data,
   type: 'bar',
   loading: false
 };
+const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
 <React.Fragment>
   <Chart
     type={state.type}
@@ -96,6 +98,7 @@ initialState = {
     domain={state.domain}
     height={500}
     loading={state.loading}
+    getCustomYLabelFormat={getCustomYLabelFormat}
   />
 </React.Fragment>
 ```

--- a/src/components/charts/line/axis-ticks.js
+++ b/src/components/charts/line/axis-ticks.js
@@ -25,26 +25,37 @@ const getYLabelformat = (unit, precision, value) => {
   return `${format(`.${2}${typeValue}`)(value)}${suffix}`;
 };
 
-export const CustomYAxisTick = ({ index, x, y, payload, unit, precision }) => (
-  <g transform={`translate(${x},${y})`}>
-    <text
-      x="0"
-      y="0"
-      dy="0"
-      textAnchor="end"
-      stroke="#b1b1c1"
-      strokeWidth="0.5"
-      fontSize="13px"
-    >
-      {
-        index === 0 &&
-          (payload.value === 0 || payload.value < 0 && payload.value > -0.001)
-          ? '0'
-          : getYLabelformat(unit, precision, payload.value)
-      }
-    </text>
-  </g>
-);
+export const CustomYAxisTick = (
+  { index, x, y, payload, unit, precision, getCustomYLabelFormat }
+) =>
+  {
+    const yLabelFormat = (_unit, _precision, value) =>
+      yLabelFormat
+        ? getCustomYLabelFormat(value)
+        : getYLabelformat(_unit, _precision, value);
+
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <text
+          x="0"
+          y="0"
+          dy="0"
+          textAnchor="end"
+          stroke="#b1b1c1"
+          strokeWidth="0.5"
+          fontSize="13px"
+        >
+          {
+            index === 0 &&
+              (payload.value === 0 ||
+                payload.value < 0 && payload.value > -0.001)
+              ? '0'
+              : yLabelFormat(unit, precision, payload.value)
+          }
+        </text>
+      </g>
+    );
+  };
 
 CustomXAxisTick.propTypes = {
   x: PropTypes.number,
@@ -60,7 +71,8 @@ CustomYAxisTick.propTypes = {
   index: PropTypes.number,
   payload: PropTypes.object,
   unit: PropTypes.oneOfType([ PropTypes.string, PropTypes.bool ]),
-  precision: PropTypes.number
+  precision: PropTypes.number,
+  getCustomYLabelFormat: PropTypes.func
 };
 
 CustomYAxisTick.defaultProps = {
@@ -69,7 +81,8 @@ CustomYAxisTick.defaultProps = {
   index: null,
   payload: {},
   unit: null,
-  precision: null
+  precision: null,
+  getCustomYLabelFormat: null
 };
 
 CustomYAxisTick.defaultProps = { precision: null, unit: false };

--- a/src/components/charts/line/axis-ticks.js
+++ b/src/components/charts/line/axis-ticks.js
@@ -30,7 +30,7 @@ export const CustomYAxisTick = (
 ) =>
   {
     const yLabelFormat = (_unit, _precision, value) =>
-      yLabelFormat
+      getCustomYLabelFormat
         ? getCustomYLabelFormat(value)
         : getYLabelformat(_unit, _precision, value);
 

--- a/src/components/charts/line/line.js
+++ b/src/components/charts/line/line.js
@@ -44,7 +44,8 @@ class ChartLine extends PureComponent {
       lineType,
       customXAxisTick,
       customYAxisTick,
-      customTooltip
+      customTooltip,
+      getCustomYLabelFormat
     } = this.props;
     const unit = showUnit &&
       config &&
@@ -89,7 +90,13 @@ class ChartLine extends PureComponent {
             type="number"
             tick={
               customYAxisTick ||
-                <CustomYAxisTick precision={config.precision} unit={unit} />
+                (
+                  <CustomYAxisTick
+                    precision={config.precision}
+                    unit={unit}
+                    getCustomYLabelFormat={getCustomYLabelFormat}
+                  />
+                )
             }
             domain={domain && domain.y || [ 'auto', 'auto' ]}
             interval="preserveStartEnd"
@@ -149,7 +156,8 @@ ChartLine.propTypes = {
   lineType: PropTypes.string,
   customYAxisTick: PropTypes.node,
   customXAxisTick: PropTypes.node,
-  customTooltip: PropTypes.node
+  customTooltip: PropTypes.node,
+  getCustomYLabelFormat: PropTypes.func
 };
 
 ChartLine.defaultProps = {
@@ -164,7 +172,8 @@ ChartLine.defaultProps = {
   lineType: 'monotone',
   customYAxisTick: null,
   customXAxisTick: null,
-  customTooltip: null
+  customTooltip: null,
+  getCustomYLabelFormat: null
 };
 
 export default ChartLine;

--- a/src/components/charts/stacked-area/axis-ticks.js
+++ b/src/components/charts/stacked-area/axis-ticks.js
@@ -25,7 +25,7 @@ export const CustomYAxisTick = (
 ) =>
   {
     const yLabelFormat = (value, _unit) =>
-      yLabelFormat
+      getCustomYLabelFormat
         ? getCustomYLabelFormat(value)
         : getYLabelformat(value, _unit);
     return (

--- a/src/components/charts/stacked-area/axis-ticks.js
+++ b/src/components/charts/stacked-area/axis-ticks.js
@@ -18,21 +18,32 @@ export const CustomXAxisTick = ({ x, y, payload, customStrokeWidth }) => (
   </g>
 );
 
-export const CustomYAxisTick = ({ x, y, payload, customStrokeWidth, unit }) => (
-  <g transform={`translate(${x},${y})`}>
-    <text
-      x="5"
-      y="4"
-      dy="0"
-      textAnchor="end"
-      stroke="#b1b1c1"
-      strokeWidth={customStrokeWidth || '0.5'}
-      fontSize="13px"
-    >
-      {payload.value === 0 ? '0' : `${format('.2s')(payload.value)}${unit}`}
-    </text>
-  </g>
-);
+const getYLabelformat = (value, unit) => `${format('.2s')(value)}${unit}`;
+
+export const CustomYAxisTick = (
+  { x, y, payload, customStrokeWidth, unit, getCustomYLabelFormat }
+) =>
+  {
+    const yLabelFormat = (value, _unit) =>
+      yLabelFormat
+        ? getCustomYLabelFormat(value)
+        : getYLabelformat(value, _unit);
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <text
+          x="5"
+          y="4"
+          dy="0"
+          textAnchor="end"
+          stroke="#b1b1c1"
+          strokeWidth={customStrokeWidth || '0.5'}
+          fontSize="13px"
+        >
+          {payload.value === 0 ? '0' : yLabelFormat(payload.value, unit)}
+        </text>
+      </g>
+    );
+  };
 
 CustomXAxisTick.propTypes = {
   x: PropTypes.number,
@@ -53,7 +64,8 @@ CustomYAxisTick.propTypes = {
   y: PropTypes.number,
   payload: PropTypes.object,
   customStrokeWidth: PropTypes.string,
-  unit: PropTypes.oneOfType([ PropTypes.string, PropTypes.bool ])
+  unit: PropTypes.oneOfType([ PropTypes.string, PropTypes.bool ]),
+  getCustomYLabelFormat: PropTypes.func
 };
 
 CustomYAxisTick.defaultProps = {
@@ -61,5 +73,6 @@ CustomYAxisTick.defaultProps = {
   y: null,
   payload: {},
   unit: null,
-  customStrokeWidth: null
+  customStrokeWidth: null,
+  getCustomYLabelFormat: null
 };

--- a/src/components/charts/stacked-area/stacked-area.js
+++ b/src/components/charts/stacked-area/stacked-area.js
@@ -106,7 +106,8 @@ class ChartStackedArea extends PureComponent {
       stepped,
       customXAxisTick,
       customYAxisTick,
-      customTooltip
+      customTooltip,
+      getCustomYLabelFormat
     } = this.props;
     const stackedAreaState = { points, data, config };
     const dataWithTotal = getDataWithTotal(stackedAreaState);
@@ -151,7 +152,13 @@ class ChartStackedArea extends PureComponent {
             tickLine={false}
             tick={
               customYAxisTick ||
-                <CustomYAxisTick customstrokeWidth="0" unit="t" />
+                (
+                  <CustomYAxisTick
+                    customstrokeWidth="0"
+                    unit="t"
+                    getCustomYLabelFormat={getCustomYLabelFormat}
+                  />
+                )
             }
             ticks={tickValues.ticks}
           />
@@ -233,7 +240,8 @@ ChartStackedArea.propTypes = {
   stepped: PropTypes.bool,
   customYAxisTick: PropTypes.node,
   customXAxisTick: PropTypes.node,
-  customTooltip: PropTypes.node
+  customTooltip: PropTypes.node,
+  getCustomYLabelFormat: PropTypes.func
 };
 
 ChartStackedArea.defaultProps = {
@@ -246,7 +254,8 @@ ChartStackedArea.defaultProps = {
   stepped: false,
   customYAxisTick: null,
   customXAxisTick: null,
-  customTooltip: null
+  customTooltip: null,
+  getCustomYLabelFormat: null
 };
 
 export default ChartStackedArea;


### PR DESCRIPTION
This PR allows passing directly to charts callback that will format y label values. `getCustomYLabelFormat` is passed to CustomYAxis component which then decided which formatting is supposed to be used.
It will allow us to pass from SA platform for example just a function formatting y values without repeating creation of CustomYAxis component just to handle y values formatting.