### PR TITLE
Fix/table width

### DIFF
--- a/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
+++ b/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
@@ -36,7 +36,7 @@ SankeyNode.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   index: PropTypes.number,
-  payload: PropTypes.shape,
+  payload: PropTypes.object,
   config: PropTypes.shape({
     unit: PropTypes.string,
     suffix: PropTypes.string

--- a/src/components/charts/sankey/sankey.js
+++ b/src/components/charts/sankey/sankey.js
@@ -54,7 +54,7 @@ SankeyChart.propTypes = {
   /** Height of the chart */
   height: PropTypes.number,
   /** Data of the chart */
-  data: PropTypes.shape,
+  data: PropTypes.shape({ nodes: PropTypes.array, links: PropTypes.array }),
   /** Width of every node */
   nodeWidth: PropTypes.number,
   /** Padding of every node */

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -37,6 +37,7 @@ class Table extends PureComponent {
     this.minColumnWidth = 50;
     this.maxColumnWidth = 300;
     this.lengthWidthRatio = 4;
+    this.columnWidthSamples = 5;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -132,8 +133,20 @@ class Table extends PureComponent {
     const columnLabel = columnSlug => capitalize(columnSlug.replace(/_/g, ' '));
 
     const getColumnLength = column => {
-      if (!data[0][column]) return this.standardColumnWidth;
-      const length = data[0][column].length * this.lengthWidthRatio;
+      let samples = 0;
+      let aggregatedLenght = 0;
+      const sampleNumbersArray = Array
+        .from(Array(this.columnWidthSamples))
+        .map((a, index) => index);
+      sampleNumbersArray.forEach(n => {
+        if (data[n][column].length) {
+          aggregatedLenght += data[n][column].length;
+          samples += 1;
+        }
+      });
+      if (samples < 1) return this.standardColumnWidth;
+      const meanLenght = aggregatedLenght / samples;
+      const length = meanLenght * this.lengthWidthRatio;
       if (length < this.minColumnWidth) return this.minColumnWidth;
       if (length > this.maxColumnWidth) return this.maxColumnWidth;
       return length;
@@ -142,12 +155,13 @@ class Table extends PureComponent {
     const columnWidthProps = column => {
       if (setColumnWidth) {
         return {
+          width: setColumnWidth(column),
           minWidth: setColumnWidth(column),
           maxWidth: setColumnWidth(column)
         };
       }
       const length = getColumnLength(column, data);
-      return { minWidth: length, maxWidth: length };
+      return { width: length, minWidth: length, maxWidth: length };
     };
     return (
       <div className={cx({ [styles.hasColumnSelect]: hasColumnSelect })}>


### PR DESCRIPTION
This PR uses an approximation based on some samples of each column of the table to give a width to each column. It has some min and max width for all the columns to prevent problems. These values are overridden if we use setColumnWidth. The use of this function is fixed too, it was not working correctly.

![image](https://user-images.githubusercontent.com/9701591/45682765-96ad2c80-bb41-11e8-95fc-e6ff4e72a538.png)
