### PR TITLE
Fix Sankey tooltip styles, use tootlipChildren as a function, update example

### DIFF
--- a/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
+++ b/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
@@ -36,7 +36,20 @@ SankeyNode.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   index: PropTypes.number,
-  payload: PropTypes.object,
+  payload: PropTypes.shape({
+    color: PropTypes.string,
+    depth: PropTypes.number,
+    dx: PropTypes.number,
+    dy: PropTypes.number,
+    name: PropTypes.string,
+    SourceLinks: PropTypes.array,
+    SourceNodes: PropTypes.array,
+    targetLinks: PropTypes.array,
+    targetNodes: PropTypes.array,
+    value: PropTypes.number,
+    x: PropTypes.number,
+    y: PropTypes.number
+  }),
   config: PropTypes.shape({
     unit: PropTypes.string,
     suffix: PropTypes.string

--- a/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
+++ b/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
@@ -41,19 +41,19 @@ class SankeyTooltip extends PureComponent {
                             node.payload.payload.source.color
                         }}
                       />
-                      <p className={styles.labelName}>
+                      <div className={styles.labelName}>
                         {
                           node.payload.payload &&
                             node.payload.payload.source &&
                             node.payload.payload.source.name
                         }
-                      </p>
+                      </div>
                     </div>
-                    <p className={styles.labelValue}>
+                    <div className={styles.labelValue}>
                       {node.value}
-                    </p>
+                    </div>
                   </div>
-                  {tooltipChildren}
+                  {tooltipChildren && tooltipChildren(node)}
                 </div>
               ) : null
             )
@@ -77,7 +77,7 @@ SankeyTooltip.propTypes = {
   config: PropTypes.shape({
     unit: PropTypes.string
   }),
-  tooltipChildren: PropTypes.node
+  tooltipChildren: PropTypes.func
 };
 
 SankeyTooltip.defaultProps = { content: null, config: {}, tooltipChildren: null };

--- a/src/components/charts/sankey/sankey.js
+++ b/src/components/charts/sankey/sankey.js
@@ -63,8 +63,8 @@ SankeyChart.propTypes = {
   containerWidth: PropTypes.number,
   /** Custom tooltip component. Will replace the default */
   customTooltip: PropTypes.node,
-  /** Components that will be added at the bottom of the tooltip */
-  tooltipChildren: PropTypes.node,
+  /** Function that takes the node info and returns the components to add at the bottom of the tooltip */
+  tooltipChildren: PropTypes.func,
   /** Configuration */
   config: PropTypes.shape({
     /** Configuration for the tooltip */

--- a/src/components/charts/sankey/sankey.md
+++ b/src/components/charts/sankey/sankey.md
@@ -32,5 +32,5 @@ initialState = {
   loading: false
 };
 
-<SankeyChart data={data} />
+<SankeyChart data={data} tooltipChildren={node => <div>Tooltip Extra Info: {node.name}</div>} />
 ```

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -244,11 +244,11 @@ class Table extends PureComponent {
 
 Table.propTypes = {
   /* Array of any kind of data you want to display */
+  // eslint-disable-next-line react/forbid-prop-types
   data: PropTypes.array.isRequired,
-  // eslint-disable-line react/forbid-prop-types
   /* Initial columns active in the table */
+  // eslint-disable-next-line react/forbid-prop-types
   defaultColumns: PropTypes.array,
-  // eslint-disable-line react/forbid-prop-types
   /* Initial column to sort by */
   sortBy: PropTypes.string,
   /* Include top right dropdown to filter active columns */
@@ -262,12 +262,12 @@ Table.propTypes = {
   /* Initial table header height */
   headerHeight: PropTypes.number,
   /* Trim line to include ... */
+  // eslint-disable-next-line react/forbid-prop-types
   ellipsisColumns: PropTypes.array,
-  // eslint-disable-line react/forbid-prop-types
   /* Boolean to allow scroll in the horizontal direction */
   horizontalScroll: PropTypes.bool.isRequired,
   /* Array to order the column headers */
-  // eslint-disable-line react/forbid-prop-types
+  // eslint-disable-next-line react/forbid-prop-types
   firstColumnHeaders: PropTypes.array
 };
 

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -189,7 +189,9 @@ class Table extends PureComponent {
               hideResetButton
               open={optionsOpen}
             >
-              <span className={styles.selectorValue}>...</span>
+              <span className={styles.selectorValue}>
+                    ...
+              </span>
             </MultiSelect>
           </div>
             )
@@ -243,8 +245,10 @@ class Table extends PureComponent {
 Table.propTypes = {
   /* Array of any kind of data you want to display */
   data: PropTypes.array.isRequired,
+  // eslint-disable-line react/forbid-prop-types
   /* Initial columns active in the table */
   defaultColumns: PropTypes.array,
+  // eslint-disable-line react/forbid-prop-types
   /* Initial column to sort by */
   sortBy: PropTypes.string,
   /* Include top right dropdown to filter active columns */
@@ -259,9 +263,11 @@ Table.propTypes = {
   headerHeight: PropTypes.number,
   /* Trim line to include ... */
   ellipsisColumns: PropTypes.array,
+  // eslint-disable-line react/forbid-prop-types
   /* Boolean to allow scroll in the horizontal direction */
   horizontalScroll: PropTypes.bool.isRequired,
   /* Array to order the column headers */
+  // eslint-disable-line react/forbid-prop-types
   firstColumnHeaders: PropTypes.array
 };
 


### PR DESCRIPTION
- Fix tooltip styles
- Add TooltipChildren as a function that will receive an object of information about the selected node to be able to use it to display extra information.
- Fix Proptypes

![image](https://user-images.githubusercontent.com/9701591/46219640-1d36ea80-c348-11e8-9bda-a65f15ad788d.png)
