### PR TITLE
Fix/sankey scale and links

### DIFF
--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -121,6 +121,7 @@ class SimpleBarChart extends PureComponent {
             />
             {dataKeys.map(dataKey => (
               <Bar
+                key={dataKey}
                 dataKey={dataKey}
                 fill={config.theme[dataKey] && config.theme[dataKey].fill}
               />

--- a/src/components/charts/sankey/sankey-link/sankey-link-component.jsx
+++ b/src/components/charts/sankey/sankey-link/sankey-link-component.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import styles from './sankey-link-styles.scss';
+
+function SankeyLink({ sourceX, sourceY, sourceControlX, targetX, targetY, targetControlX, linkWidth }) {
+  return (
+    <path
+      className={styles.link}
+      d={`
+        M${sourceX},${sourceY}
+        C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}
+      `}
+      fill="none"
+      stroke="#333"
+      strokeWidth={linkWidth}
+      strokeOpacity="0.2"
+    />
+  );
+}
+
+SankeyLink.propTypes = {
+  sourceX: PropTypes.number,
+  targetX: PropTypes.number,
+  sourceY: PropTypes.number,
+  targetY: PropTypes.number,
+  sourceControlX: PropTypes.number,
+  targetControlX: PropTypes.number,
+  linkWidth: PropTypes.number
+};
+
+SankeyLink.defaultProps = {
+  sourceX: null,
+  targetX: null,
+  sourceY: null,
+  targetY: null,
+  sourceControlX: null,
+  targetControlX: null,
+  linkWidth: null
+};
+
+export default SankeyLink;

--- a/src/components/charts/sankey/sankey-link/sankey-link-styles.scss
+++ b/src/components/charts/sankey/sankey-link/sankey-link-styles.scss
@@ -1,0 +1,9 @@
+@import '~styles/settings.scss';
+
+.link {
+  cursor: pointer;
+
+  &:hover {
+    stroke-opacity: 0.3;
+  }
+}

--- a/src/components/charts/sankey/sankey-link/sankey-link.js
+++ b/src/components/charts/sankey/sankey-link/sankey-link.js
@@ -1,0 +1,3 @@
+import Component from './sankey-link-component';
+
+export default Component;

--- a/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
+++ b/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Rectangle, Layer } from 'recharts';
 import { PropTypes } from 'prop-types';
+import { format } from 'd3-format';
 import styles from './sankey-node-styles.scss';
 
 function SankeyNode({ x, y, width, height, index, payload, config, containerWidth }) {
@@ -8,6 +9,8 @@ function SankeyNode({ x, y, width, height, index, payload, config, containerWidt
   const isOut = x + width + padding > containerWidth;
   const unit = config.unit ? `${config.unit} ` : '';
   const suffix = config.suffix ? ` ${config.suffix}` : '';
+  const scale = config.scale || 1;
+  const valueFormat = config.format || '~r';
   return (
     <Layer key={`CustomNode${index}`}>
       <Rectangle
@@ -24,7 +27,7 @@ function SankeyNode({ x, y, width, height, index, payload, config, containerWidt
         y={y + height / 2}
         className={styles.nodeText}
       >
-        {`${payload.name}: ${unit}${payload.value}${suffix}`}
+        {`${payload.name}: ${unit}${format(valueFormat)(payload.value * scale)}${suffix}`}
       </text>
     </Layer>
   );

--- a/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
+++ b/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
@@ -4,9 +4,9 @@ import { PropTypes } from 'prop-types';
 import { format } from 'd3-format';
 import styles from './sankey-node-styles.scss';
 
-function SankeyNode({ x, y, width, height, index, payload, config, containerWidth }) {
+function SankeyNode({ x, y, width, height, index, payload, config }) {
   const padding = 20;
-  const isOut = x + width + padding > containerWidth;
+  const isOut = x > width;
   const unit = config.unit ? `${config.unit} ` : '';
   const suffix = config.suffix ? ` ${config.suffix}` : '';
   const scale = config.scale || 1;
@@ -56,8 +56,7 @@ SankeyNode.propTypes = {
   config: PropTypes.shape({
     unit: PropTypes.string,
     suffix: PropTypes.string
-  }),
-  containerWidth: PropTypes.number
+  })
 };
 
 SankeyNode.defaultProps = {
@@ -67,8 +66,7 @@ SankeyNode.defaultProps = {
   height: 20,
   index: 0,
   payload: {},
-  config: {},
-  containerWidth: 100
+  config: {}
 };
 
 export default SankeyNode;

--- a/src/components/charts/sankey/sankey-styles.scss
+++ b/src/components/charts/sankey/sankey-styles.scss
@@ -1,0 +1,9 @@
+@import '~styles/settings.scss';
+
+.link {
+  cursor: pointer;
+
+  &:hover {
+    stroke-opacity: 0.3;
+  }
+}

--- a/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
+++ b/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
@@ -1,11 +1,14 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-
+import { format } from 'd3-format';
 import styles from './sankey-tooltip-styles.scss';
 
 class SankeyTooltip extends PureComponent {
   render() {
     const { config, content, tooltipChildren } = this.props;
+    const suffix = config.suffix ? ` ${config.suffix}` : '';
+    const scale = config.scale || 1;
+    const valueFormat = config.format || '~r';
     return (
       <div className={styles.tooltip}>
         {
@@ -50,7 +53,7 @@ class SankeyTooltip extends PureComponent {
                       </div>
                     </div>
                     <div className={styles.labelValue}>
-                      {node.value}
+                      {`${format(valueFormat)(node.value * scale)}${suffix}`}
                     </div>
                   </div>
                   {tooltipChildren && tooltipChildren(node)}

--- a/src/components/charts/sankey/sankey.js
+++ b/src/components/charts/sankey/sankey.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Sankey, Tooltip, ResponsiveContainer } from 'recharts';
 import SankeyTooltip from './sankey-tooltip';
+import SankeyLink from './sankey-link';
 import SankeyNode from './sankey-node';
 
 function SankeyChart(
@@ -14,6 +15,8 @@ function SankeyChart(
     data,
     config,
     customTooltip,
+    customLink,
+    customNode,
     tooltipChildren
   }
 ) {
@@ -25,8 +28,10 @@ function SankeyChart(
         data={data}
         nodeWidth={nodeWidth}
         nodePadding={nodePadding}
+        link={customLink || <SankeyLink />}
         node={
-          <SankeyNode containerWidth={containerWidth} config={config.node} />
+          customNode ||
+            <SankeyNode containerWidth={containerWidth} config={config.node} />
         }
       >
         {
@@ -63,6 +68,10 @@ SankeyChart.propTypes = {
   containerWidth: PropTypes.number,
   /** Custom tooltip component. Will replace the default */
   customTooltip: PropTypes.node,
+  /** Custom link component. Will replace the default */
+  customLink: PropTypes.node,
+  /** Custom node component. Will replace the default */
+  customNode: PropTypes.node,
   /** Function that takes the node info and returns the components to add at the bottom of the tooltip */
   tooltipChildren: PropTypes.func,
   /** Configuration */
@@ -85,6 +94,8 @@ SankeyChart.defaultProps = {
   containerWidth: 800,
   config: {},
   customTooltip: null,
+  customLink: null,
+  customNode: null,
   tooltipChildren: null
 };
 

--- a/src/components/charts/sankey/sankey.md
+++ b/src/components/charts/sankey/sankey.md
@@ -20,10 +20,11 @@ const data = {
     }
   ],
   links: [
-    { source: 0, target: 2, value: 24 },
-    { source: 1, target: 3, value: 15 },
-    { source: 1, target: 3, value: 19 },
-    { source: 0, target: 3, value: 57 }
+    { source: 0, target: 2, value: 240000 },
+    { source: 0, target: 2, value: 940000 },
+    { source: 1, target: 3, value: 150000 },
+    { source: 1, target: 3, value: 190000 },
+    { source: 0, target: 3, value: 5700000 }
   ]
 };
 
@@ -31,6 +32,18 @@ initialState = {
   ...data,
   loading: false
 };
+const config = {
+  tooltip:
+    {
+      scale: 1/100000,
+      suffix: 'm'
+    },
+  node:
+    {
+      scale: 1/100000,
+      suffix: 'm'
+    }
+};
 
-<SankeyChart data={data} tooltipChildren={node => <div>Tooltip Extra Info: {node.name}</div>} />
+<SankeyChart data={data} config={config} tooltipChildren={node => <div>Tooltip Extra Info: {node.name}</div>} />
 ```

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -85,7 +85,6 @@
   }
 
   .ReactVirtualized__Table__row {
-    border-bottom: solid 1px #e5e5eb;
     align-items: flex-start;
     padding: 10px 0;
   }

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -34,7 +34,7 @@ class Table extends PureComponent {
         []
     };
     this.standardColumnWidth = 180;
-    this.minColumnWidth = 50;
+    this.minColumnWidth = 80;
     this.maxColumnWidth = 300;
     this.lengthWidthRatio = 4;
     this.columnWidthSamples = 5;
@@ -125,7 +125,13 @@ class Table extends PureComponent {
       column
     );
     const length = meanLenght * this.lengthWidthRatio;
+    const arrowPadding = 8;
+    const columnTitleLength = (column.length + arrowPadding) *
+      this.lengthWidthRatio;
+
     if (length < this.minColumnWidth) return this.minColumnWidth;
+    if (columnTitleLength > this.minColumnWidth && length < columnTitleLength)
+      return columnTitleLength;
     if (length > this.maxColumnWidth) return this.maxColumnWidth;
     return length;
   };

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -38,6 +38,8 @@ class Table extends PureComponent {
     this.maxColumnWidth = 300;
     this.lengthWidthRatio = 4;
     this.columnWidthSamples = 5;
+    this.minRowHeight = 80;
+    this.rowHeightWithEllipsis = 150;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -175,7 +177,11 @@ class Table extends PureComponent {
     if (!data.length) return null;
     const hasColumnSelectedOptions = hasColumnSelect && columnsOptions;
     const columnLabel = columnSlug => capitalize(columnSlug.replace(/_/g, ' '));
-
+    const rowsHeight = d => {
+      if (setRowsHeight) return setRowsHeight(d);
+      if (ellipsisColumns.length > 0) return this.rowHeightWithEllipsis;
+      return this.minRowHeight;
+    };
     return (
       <div className={cx({ [styles.hasColumnSelect]: hasColumnSelect })}>
         {
@@ -215,7 +221,7 @@ class Table extends PureComponent {
                 height={tableHeight}
                 headerHeight={headerHeight}
                 rowClassName={this.rowClassName}
-                rowHeight={({ index }) => setRowsHeight(data[index])}
+                rowHeight={({ index }) => rowsHeight(data[index])}
                 rowCount={data.length}
                 sort={this.handleSortChange}
                 sortBy={sortBy}
@@ -284,7 +290,7 @@ Table.defaultProps = {
   defaultColumns: [],
   hasColumnSelect: false,
   setColumnWidth: null,
-  setRowsHeight: () => 80,
+  setRowsHeight: null,
   ellipsisColumns: [],
   firstColumnHeaders: []
 };


### PR DESCRIPTION
Sankey graph:
- Fixes the problem with narrow screens
- Highlights the hovered link and adds the customLink and customNode props
- Use d3 format and scale for the values in node and tooltip. Scale will help with displaying million units for example.

Table:
- Make columns at least as wide as the column name

Barchart
- Add a missing key to avoid warning

![image](https://user-images.githubusercontent.com/9701591/46535554-0f371b80-c8ac-11e8-93fa-9235a9e77f85.png)
