### PR TITLE
Feature/standardise custom suffix and format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "0.1.0",
+  "version": "1.6.4",
   "private": true,
   "main": "dist/bundle.js",
   "scripts": {

--- a/src/components/charts/assets/data-for-composed-chart.js
+++ b/src/components/charts/assets/data-for-composed-chart.js
@@ -1,7 +1,12 @@
 export const config = {
   axes: {
     xBottom: { name: 'Year', unit: 'date', format: 'YYYY' },
-    yLeft: { name: 'Emissions', unit: 'CO<sub>2</sub>e', format: 'number' }
+    yLeft: {
+      name: 'Emissions',
+      unit: 'CO<sub>2</sub>e',
+      format: 'number',
+      suffix: 't'
+    }
   },
   theme: {
     yAllGhg: { stroke: '#9854b1', fill: '#9854b1' },

--- a/src/components/charts/assets/data-with-grey-area.json
+++ b/src/components/charts/assets/data-with-grey-area.json
@@ -5,7 +5,8 @@
       "yLeft": {
         "name": "GDP Growth",
         "unit": "",
-        "format": "number"
+        "format": "number",
+        "suffix": "t"
       }
     },
     "theme": {

--- a/src/components/charts/assets/data.js
+++ b/src/components/charts/assets/data.js
@@ -1,7 +1,12 @@
 export const config = {
   axes: {
     xBottom: { name: 'Year', unit: 'date', format: 'YYYY' },
-    yLeft: { name: 'Emissions', unit: 'CO<sub>2</sub>e', format: 'number' }
+    yLeft: {
+      name: 'Emissions',
+      unit: 'CO<sub>2</sub>e',
+      format: 'number',
+      suffix: 't'
+    }
   },
   theme: {
     yAllGhg: { stroke: '#9854b1', fill: '#9854b1' },

--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -116,6 +116,7 @@ class SimpleBarChart extends PureComponent {
                       content={content}
                       config={config}
                       forceFixedFormatDecimals={forceFixedFormatDecimals}
+                      getCustomYLabelFormat={getCustomYLabelFormat}
                     />
                   )}
             />

--- a/src/components/charts/chart-composed/chart-composed.js
+++ b/src/components/charts/chart-composed/chart-composed.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import has from 'lodash/has';
 
 import {
   XAxis,
@@ -61,11 +62,13 @@ class ChartComposed extends PureComponent {
     } = this.props;
     const unit = showUnit &&
       config &&
-      config.axes &&
-      config.axes.yLeft &&
-      config.axes.yLeft.unit
-      ? config.axes.yLeft.unit
-      : null;
+      has(config, 'axes.yLeft.unit') &&
+      config.axes.yLeft.unit ||
+      null;
+    const suffix = config &&
+      has(config, 'axes.yLeft.suffix') &&
+      config.axes.yLeft.suffix ||
+      null;
     const LineChartMargin = { top: 10, right: 0, left: -10, bottom: 0 };
     const hasDataOptions = !loading && dataOptions;
     const yAxisLabel = (
@@ -109,6 +112,7 @@ class ChartComposed extends PureComponent {
                     <CustomYAxisTick
                       precision={config.precision}
                       unit={unit}
+                      suffix={suffix}
                       getCustomYLabelFormat={getCustomYLabelFormat}
                     />
                   )
@@ -131,6 +135,7 @@ class ChartComposed extends PureComponent {
                       content={content}
                       config={config}
                       forceFixedFormatDecimals={forceFixedFormatDecimals}
+                      getCustomYLabelFormat={getCustomYLabelFormat}
                     />
                   )}
             />

--- a/src/components/charts/chart-composed/chart-composed.md
+++ b/src/components/charts/chart-composed/chart-composed.md
@@ -3,6 +3,7 @@ const data = require('../assets/data-for-composed-chart.js');
 const Line = require('recharts').Line;
 const Area = require('recharts').Area;
 const isUndefined = require('lodash/isUndefined');
+const format = require('d3-format').format;
 
 initialState = {
   ...data,
@@ -30,7 +31,6 @@ const handleLegendChange = (filtersSelected) => {
     }
   })
 }
-
 const rangedArea = config.columns && config.columns.rangedArea.map(column => {
                   const color = config.theme[column.value].stroke || '';
                   return (
@@ -126,7 +126,6 @@ initialState = {
   loading: false
 };
 
-const config = { ...state.config };
 
 const lineChart = (
   <Line

--- a/src/components/charts/chart-config.md
+++ b/src/components/charts/chart-config.md
@@ -29,7 +29,7 @@
     label: ''
     prefix: '' // optional
     format: // just in case you want to show it in a different axes way
-    sufix: '' // optional
+    suffix: '' // optional
     type: number | date ...
   }
 }

--- a/src/components/charts/chart/chart.js
+++ b/src/components/charts/chart/chart.js
@@ -101,8 +101,35 @@ Chart.propTypes = {
   onLegendChange: PropTypes.func,
   /** Array of chart data */
   data: PropTypes.array.isRequired,
-  /** Array of chart data */
-  config: PropTypes.object.isRequired,
+  /** Array of chart data -
+   * Axes.yLeft has name, unit, format, suffix
+   * */
+  config: PropTypes.shape({
+    animation: PropTypes.bool,
+    axes: PropTypes.shape({
+      xBottom: PropTypes.shape({
+        name: PropTypes.string,
+        unit: PropTypes.string,
+        format: PropTypes.string,
+        suffix: PropTypes.string
+      }),
+      yLeft: PropTypes.shape({
+        name: PropTypes.string,
+        unit: PropTypes.string,
+        format: PropTypes.string,
+        suffix: PropTypes.string
+      })
+    }),
+    columns: PropTypes.objectOf(
+      PropTypes.arrayOf(
+        PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })
+      )
+    ),
+    theme: PropTypes.objectOf(
+      PropTypes.shape({ stroke: PropTypes.string, fill: PropTypes.string })
+    ),
+    tooltip: PropTypes.objectOf(PropTypes.shape({ label: PropTypes.string }))
+  }).isRequired,
   /** Initial height of the chart in number or % */
   height: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
   /** Data model url and image */

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -1,5 +1,7 @@
 ```js
+const format = require('d3-format').format;
 const data = require('../assets/data.js');
+
 initialState = {
   ...data,
   type: 'line',
@@ -17,6 +19,7 @@ const handleLegendChange = (filtersSelected) => {
     }
   })
 }
+const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
 const toggleCharType = (filtersSelected) => {
   setState(state => ({ type: state.type === 'line' ? 'area' : 'line' }))
 }
@@ -34,6 +37,7 @@ const toggleCharType = (filtersSelected) => {
     height={500}
     loading={state.loading}
     onLegendChange={handleLegendChange}
+    getCustomYLabelFormat={getCustomYLabelFormat}
   />
 </React.Fragment>
 ```

--- a/src/components/charts/line/axis-ticks.js
+++ b/src/components/charts/line/axis-ticks.js
@@ -21,19 +21,17 @@ export const CustomXAxisTick = ({ x, y, payload }) => (
 const getYLabelformat = (unit, precision, value) => {
   let typeValue = unit ? 'r' : 's';
   if (precision) typeValue = 'f';
-  const suffix = unit ? '' : 't';
-  return `${format(`.${2}${typeValue}`)(value)}${suffix}`;
+  return `${format(`.${2}${typeValue}`)(value)}`;
 };
 
 export const CustomYAxisTick = (
-  { index, x, y, payload, unit, precision, getCustomYLabelFormat }
+  { index, x, y, payload, unit, precision, getCustomYLabelFormat, suffix }
 ) =>
   {
     const yLabelFormat = (_unit, _precision, value) =>
       getCustomYLabelFormat
         ? getCustomYLabelFormat(value)
         : getYLabelformat(_unit, _precision, value);
-
     return (
       <g transform={`translate(${x},${y})`}>
         <text
@@ -50,7 +48,7 @@ export const CustomYAxisTick = (
               (payload.value === 0 ||
                 payload.value < 0 && payload.value > -0.001)
               ? '0'
-              : yLabelFormat(unit, precision, payload.value)
+              : `${yLabelFormat(unit, precision, payload.value)}${suffix || ''}`
           }
         </text>
       </g>
@@ -71,6 +69,7 @@ CustomYAxisTick.propTypes = {
   index: PropTypes.number,
   payload: PropTypes.object,
   unit: PropTypes.oneOfType([ PropTypes.string, PropTypes.bool ]),
+  suffix: PropTypes.string,
   precision: PropTypes.number,
   getCustomYLabelFormat: PropTypes.func
 };
@@ -81,6 +80,7 @@ CustomYAxisTick.defaultProps = {
   index: null,
   payload: {},
   unit: null,
+  suffix: null,
   precision: null,
   getCustomYLabelFormat: null
 };

--- a/src/components/charts/line/line.js
+++ b/src/components/charts/line/line.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-
+import has from 'lodash/has';
 import {
   LineChart,
   Line,
@@ -47,12 +47,11 @@ class ChartLine extends PureComponent {
       customTooltip,
       getCustomYLabelFormat
     } = this.props;
-    const unit = showUnit &&
-      config &&
-      config.axes &&
-      config.axes.yLeft &&
-      config.axes.yLeft.unit
+    const unit = showUnit && has(config, 'axes.yLeft.unit')
       ? config.axes.yLeft.unit
+      : null;
+    const suffix = has(config, 'axes.yLeft.suffix')
+      ? config.axes.yLeft.suffix
       : null;
     const LineChartMargin = { top: 10, right: 0, left: -10, bottom: 0 };
     const yAxisLabel = (
@@ -94,6 +93,7 @@ class ChartLine extends PureComponent {
                   <CustomYAxisTick
                     precision={config.precision}
                     unit={unit}
+                    suffix={suffix}
                     getCustomYLabelFormat={getCustomYLabelFormat}
                   />
                 )
@@ -116,6 +116,7 @@ class ChartLine extends PureComponent {
                     content={content}
                     config={config}
                     forceFixedFormatDecimals={forceFixedFormatDecimals}
+                    getCustomYLabelFormat={getCustomYLabelFormat}
                   />
                 )}
           />

--- a/src/components/charts/stacked-area/stacked-area.js
+++ b/src/components/charts/stacked-area/stacked-area.js
@@ -182,6 +182,7 @@ class ChartStackedArea extends PureComponent {
                           content={content}
                           config={config}
                           showTotal
+                          getCustomYLabelFormat={getCustomYLabelFormat}
                         />
                       )}
                   filterNull={false}

--- a/src/components/charts/tooltip-chart/tooltip-chart.js
+++ b/src/components/charts/tooltip-chart/tooltip-chart.js
@@ -7,12 +7,15 @@ import Icon from 'components/icon';
 import styles from './tooltip-chart-styles.scss';
 
 class TooltipChart extends PureComponent {
-  getFormat() {
-    const { forceFixedFormatDecimals } = this.props;
-    return forceFixedFormatDecimals ? `.${forceFixedFormatDecimals}f` : '.2s';
+  formatValue(value) {
+    const { forceFixedFormatDecimals, getCustomYLabelFormat } = this.props;
+    if (getCustomYLabelFormat) return getCustomYLabelFormat(value);
+    return format(
+      forceFixedFormatDecimals ? `.${forceFixedFormatDecimals}f` : '.2s'
+    )(value);
   }
 
-  getTotal = (keys, data, unitIsCo2) => {
+  getTotal = (keys, data, suffix) => {
     if (!keys || !data) return '';
     let total = 0;
     let hasData = false;
@@ -22,9 +25,7 @@ class TooltipChart extends PureComponent {
         total += data.payload[key.value];
       }
     });
-    return hasData
-      ? `${format(this.getFormat())(total)}${unitIsCo2 ? 't' : ''}`
-      : 'n/a';
+    return hasData ? `${this.formatValue(total)}${suffix || ''}` : 'n/a';
   };
 
   sortByValue = payload => {
@@ -37,16 +38,14 @@ class TooltipChart extends PureComponent {
     return payload.sort(compare);
   };
 
-  renderValue = (y, unitIsCo2) => {
+  renderValue = (y, suffix) => {
     if (y.payload && y.payload[y.dataKey] !== undefined) {
       if (Array.isArray(y.payload[y.dataKey])) {
-        return `${format(
-          this.getFormat()
-        )(y.payload[y.dataKey][0])} - ${format(this.getFormat())(y.payload[y.dataKey][1])} ${unitIsCo2 ? 't' : ''}`;
+        return `${this.formatValue(
+          y.payload[y.dataKey][0]
+        )} - ${this.formatValue(y.payload[y.dataKey][1])}${suffix || ''}`;
       }
-      return `${format(
-        this.getFormat()
-      )(y.payload[y.dataKey])}${unitIsCo2 ? 't' : ''}`;
+      return `${this.formatValue(y.payload[y.dataKey])}${suffix || ''}`;
     }
     return 'n/a';
   };
@@ -57,7 +56,10 @@ class TooltipChart extends PureComponent {
       config.axes &&
       config.axes.yLeft &&
       config.axes.yLeft.unit;
-    const unitIsCo2 = unit === 'CO<sub>2</sub>e';
+    const suffix = config &&
+      config.axes &&
+      config.axes.yLeft &&
+      config.axes.yLeft.suffix;
     return (
       <div className={styles.tooltip}>
         <div className={styles.tooltipHeader}>
@@ -73,13 +75,11 @@ class TooltipChart extends PureComponent {
         {
           showTotal && (
           <div className={cx(styles.label, styles.labelTotal)}>
-            <p>TOTAL</p>
             <p>
-              {this.getTotal(
-                    config.columns.y,
-                    content.payload[0],
-                    unitIsCo2
-                  )}
+                  TOTAL
+            </p>
+            <p>
+              {this.getTotal(config.columns.y, content.payload[0], suffix)}
             </p>
           </div>
             )
@@ -122,14 +122,20 @@ class TooltipChart extends PureComponent {
                         </p>
                       </div>
                       <p className={styles.labelValue}>
-                        {this.renderValue(y, unitIsCo2)}
+                        {this.renderValue(y, suffix)}
                       </p>
                     </div>
 )
                   : null
             )
         }
-        {content && !content.payload && <div>No data fool</div>}
+        {
+          content && !content.payload && (
+          <div>
+                No data
+          </div>
+            )
+        }
       </div>
     );
   }
@@ -139,12 +145,14 @@ TooltipChart.propTypes = {
   content: Proptypes.object.isRequired,
   config: Proptypes.object.isRequired,
   showTotal: Proptypes.bool,
-  forceFixedFormatDecimals: Proptypes.number
+  forceFixedFormatDecimals: Proptypes.number,
+  getCustomYLabelFormat: Proptypes.func
 };
 
 TooltipChart.defaultProps = {
   showTotal: false,
-  forceFixedFormatDecimals: null
+  forceFixedFormatDecimals: null,
+  getCustomYLabelFormat: null
 };
 
 export default TooltipChart;


### PR DESCRIPTION
This PR uses a suffix and the getCustomYLabelFormat function in all the chart values so it could be modified without using customTooltips, ...

- Use getCustomYLabelFormat in tooltip
- Remove default t suffix
- Add a suffix prop to configure it
- Update docs with some more info about the config
- Update package.json version to show it in the Styleguidist doc