### PR TITLE
Fix/area chart suffix

### DIFF
--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -19,7 +19,8 @@ import BarTooltipChart from './bar-tooltip-chart';
 class SimpleBarChart extends PureComponent {
   debouncedMouseMove = debounce(
     year => {
-      this.props.onMouseMove(year);
+      const { onMouseMove } = this.props;
+      onMouseMove(year);
     },
     80
   );

--- a/src/components/charts/chart-composed/chart-composed.js
+++ b/src/components/charts/chart-composed/chart-composed.js
@@ -25,7 +25,8 @@ import styles from './chart-composed-styles.scss';
 class ChartComposed extends PureComponent {
   debouncedMouseMove = debounce(
     year => {
-      this.props.onMouseMove(year);
+      const { onMouseMove } = this.props;
+      onMouseMove(year);
     },
     80
   );

--- a/src/components/charts/stacked-area/axis-ticks.js
+++ b/src/components/charts/stacked-area/axis-ticks.js
@@ -18,16 +18,16 @@ export const CustomXAxisTick = ({ x, y, payload, customStrokeWidth }) => (
   </g>
 );
 
-const getYLabelformat = (value, unit) => `${format('.2s')(value)}${unit}`;
+const getYLabelformat = value => `${format('.2s')(value)}`;
 
 export const CustomYAxisTick = (
-  { x, y, payload, customStrokeWidth, unit, getCustomYLabelFormat }
+  { x, y, payload, customStrokeWidth, getCustomYLabelFormat, suffix }
 ) =>
   {
-    const yLabelFormat = (value, _unit) =>
+    const yLabelFormat = value =>
       getCustomYLabelFormat
         ? getCustomYLabelFormat(value)
-        : getYLabelformat(value, _unit);
+        : getYLabelformat(value);
     return (
       <g transform={`translate(${x},${y})`}>
         <text
@@ -39,7 +39,11 @@ export const CustomYAxisTick = (
           strokeWidth={customStrokeWidth || '0.5'}
           fontSize="13px"
         >
-          {payload.value === 0 ? '0' : yLabelFormat(payload.value, unit)}
+          {
+            payload.value === 0
+              ? '0'
+              : `${yLabelFormat(payload.value)}${suffix || ''}`
+          }
         </text>
       </g>
     );
@@ -64,7 +68,7 @@ CustomYAxisTick.propTypes = {
   y: PropTypes.number,
   payload: PropTypes.object,
   customStrokeWidth: PropTypes.string,
-  unit: PropTypes.oneOfType([ PropTypes.string, PropTypes.bool ]),
+  suffix: PropTypes.string,
   getCustomYLabelFormat: PropTypes.func
 };
 
@@ -72,7 +76,7 @@ CustomYAxisTick.defaultProps = {
   x: null,
   y: null,
   payload: {},
-  unit: null,
+  suffix: null,
   customStrokeWidth: null,
   getCustomYLabelFormat: null
 };

--- a/src/components/charts/stacked-area/stacked-area.js
+++ b/src/components/charts/stacked-area/stacked-area.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 import { isMicrosoftBrowser, getCustomTicks } from 'utils';
 import isUndefined from 'lodash/isUndefined';
+import has from 'lodash/has';
 
 import {
   ComposedChart,
@@ -123,6 +124,10 @@ class ChartStackedArea extends PureComponent {
       dataWithTotal.concat(points),
       5
     );
+    const unit = has(config, 'axes.yLeft.unit') ? config.axes.yLeft.unit : null;
+    const suffix = has(config, 'axes.yLeft.suffix')
+      ? config.axes.yLeft.suffix
+      : null;
     return (
       <ResponsiveContainer height={height}>
         <ComposedChart
@@ -155,7 +160,8 @@ class ChartStackedArea extends PureComponent {
                 (
                   <CustomYAxisTick
                     customstrokeWidth="0"
-                    unit="t"
+                    unit={unit}
+                    suffix={suffix}
                     getCustomYLabelFormat={getCustomYLabelFormat}
                   />
                 )

--- a/src/components/charts/stacked-area/stacked-area.js
+++ b/src/components/charts/stacked-area/stacked-area.js
@@ -124,7 +124,6 @@ class ChartStackedArea extends PureComponent {
       dataWithTotal.concat(points),
       5
     );
-    const unit = has(config, 'axes.yLeft.unit') ? config.axes.yLeft.unit : null;
     const suffix = has(config, 'axes.yLeft.suffix')
       ? config.axes.yLeft.suffix
       : null;
@@ -160,7 +159,6 @@ class ChartStackedArea extends PureComponent {
                 (
                   <CustomYAxisTick
                     customstrokeWidth="0"
-                    unit={unit}
                     suffix={suffix}
                     getCustomYLabelFormat={getCustomYLabelFormat}
                   />

--- a/src/components/charts/tooltip-chart/tooltip-chart-styles.scss
+++ b/src/components/charts/tooltip-chart/tooltip-chart-styles.scss
@@ -1,5 +1,9 @@
 @import '~styles/settings.scss';
 
+:global .recharts-tooltip-wrapper {
+  z-index: 1;
+}
+
 .tooltip {
   background: $white;
   min-width: 180px;


### PR DESCRIPTION
This PR fixes the area chart missing suffix

![image](https://user-images.githubusercontent.com/9701591/47007642-fa267c00-d138-11e8-974b-f50606cd88fa.png)

Extra:

- Tooltip z-index fixed (The position of the tooltip in the image is just for testing)

Before:
![image](https://user-images.githubusercontent.com/9701591/47011078-3f4eac00-d141-11e8-8042-67d5b133d88f.png)

After:
![image](https://user-images.githubusercontent.com/9701591/47010982-ee3eb800-d140-11e8-8069-0df5d5db7ec1.png)
