### PR TITLE
Allow dynamic row height in table

### DIFF
--- a/src/components/table/data.json
+++ b/src/components/table/data.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "BC",
-    "definition": "Black carbon emissions from the agriculture sector",
+    "definition": "Black carbon emissions from the agriculture sector, Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions from the agriculture sector Black carbon emissions",
     "unit": "kt/yr",
     "composite_name": "Agriculture, Land Use and Forestry|Agriculture Pollutants|BC",
     "stackable": false,

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -18,6 +18,10 @@
   background-color: $light-gray;
 }
 
+.overflowVisible {
+  overflow: visible !important;
+}
+
 .table :global {
   position: relative;
 

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -18,8 +18,8 @@
   background-color: $light-gray;
 }
 
-.overflowVisible {
-  overflow: visible !important;
+.allTextVisible {
+  display: inherit !important;
 }
 
 .table :global {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -143,7 +143,6 @@ class Table extends PureComponent {
         else aggregatedLength[key] += 0;
       });
     });
-
     const greatestLength = Math.max(...Object.values(aggregatedLength));
     const columnName = Object
       .keys(aggregatedLength)
@@ -221,8 +220,8 @@ class Table extends PureComponent {
     const getDynamicRowHeight = index => {
       const considerableMargin = 100;
       const greatestColumnName = this.getLongestTextColumnName();
-      return getDatum(data, index).definition &&
-        getDatum(data, index)[greatestColumnName].split(' ').length * 2 +
+      return getDatum(data, index)[greatestColumnName] &&
+        getDatum(data, index)[greatestColumnName].length / 3 +
           considerableMargin ||
         120;
     };

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -252,7 +252,7 @@ class Table extends PureComponent {
                       className={cx(styles.column, {
                         [styles.ellipsis]: ellipsisColumns &&
                           ellipsisColumns.indexOf(column) > -1,
-                        [styles.overflowVisible]: dynamicRowsHeight
+                        [styles.allTextVisible]: dynamicRowsHeight
                       })}
                       key={column}
                       label={columnLabel(column)}

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -38,6 +38,7 @@ class Table extends PureComponent {
     this.maxColumnWidth = 300;
     this.lengthWidthRatio = 4;
     this.columnWidthSamples = 5;
+    this.columnHeightSamples = 10;
     this.minRowHeight = 80;
     this.rowHeightWithEllipsis = 150;
   }
@@ -121,6 +122,35 @@ class Table extends PureComponent {
     return aggregatedLenght / samples;
   };
 
+  getLongestTextColumnName = () => {
+    const { data } = this.props;
+
+    const columnsTextLengthSamples = [];
+    [ ...Array(this.columnHeightSamples).keys() ].forEach(n => {
+      const keys = data[n] && Object.keys(data[n]);
+      const columnsTextLength = {};
+      keys.forEach(column => {
+        columnsTextLength[column] = data[n][column].length;
+      });
+      columnsTextLengthSamples.push(columnsTextLength);
+    });
+
+    const aggregatedLength = {};
+    columnsTextLengthSamples.forEach(sample => {
+      Object.keys(sample).forEach(key => {
+        if (!aggregatedLength[key]) aggregatedLength[key] = 0;
+        if (sample[key]) aggregatedLength[key] += sample[key];
+        else aggregatedLength[key] += 0;
+      });
+    });
+
+    const greatestLength = Math.max(...Object.values(aggregatedLength));
+    const columnName = Object
+      .keys(aggregatedLength)
+      .find(column => aggregatedLength[column] === greatestLength);
+    return columnName;
+  };
+
   getColumnLength = (data, column) => {
     const meanLenght = this.getMeanLength(
       this.columnWidthSamples,
@@ -190,8 +220,9 @@ class Table extends PureComponent {
 
     const getDynamicRowHeight = index => {
       const considerableMargin = 100;
+      const greatestColumnName = this.getLongestTextColumnName();
       return getDatum(data, index).definition &&
-        getDatum(data, index).definition.split(' ').length * 2 +
+        getDatum(data, index)[greatestColumnName].split(' ').length * 2 +
           considerableMargin ||
         120;
     };

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -103,6 +103,7 @@ class Table extends PureComponent {
 
   rowClassName = ({ index }) => {
     if (index < 0) return styles.headerRow;
+
     return index % 2 === 0 ? styles.evenRow : styles.oddRow;
   };
 
@@ -190,7 +191,7 @@ class Table extends PureComponent {
     const getDynamicRowHeight = index => {
       const considerableMargin = 100;
       return getDatum(data, index).definition &&
-        getDatum(data, index).definition.split(' ').length +
+        getDatum(data, index).definition.split(' ').length * 2 +
           considerableMargin ||
         120;
     };
@@ -250,7 +251,8 @@ class Table extends PureComponent {
                     <Column
                       className={cx(styles.column, {
                         [styles.ellipsis]: ellipsisColumns &&
-                          ellipsisColumns.indexOf(column) > -1
+                          ellipsisColumns.indexOf(column) > -1,
+                        [styles.overflowVisible]: dynamicRowsHeight
                       })}
                       key={column}
                       label={columnLabel(column)}

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -171,17 +171,30 @@ class Table extends PureComponent {
       headerHeight,
       setRowsHeight,
       ellipsisColumns,
-      horizontalScroll
+      horizontalScroll,
+      dynamicRowsHeight
     } = this.props;
 
     if (!data.length) return null;
     const hasColumnSelectedOptions = hasColumnSelect && columnsOptions;
     const columnLabel = columnSlug => capitalize(columnSlug.replace(/_/g, ' '));
+
     const rowsHeight = d => {
       if (setRowsHeight) return setRowsHeight(d);
       if (ellipsisColumns.length > 0) return this.rowHeightWithEllipsis;
       return this.minRowHeight;
     };
+
+    const getDatum = (dataD, index) => dataD[index];
+
+    const getDynamicRowHeight = index => {
+      const considerableMargin = 100;
+      return getDatum(data, index).definition &&
+        getDatum(data, index).definition.split(' ').length +
+          considerableMargin ||
+        120;
+    };
+
     return (
       <div className={cx({ [styles.hasColumnSelect]: hasColumnSelect })}>
         {
@@ -221,7 +234,10 @@ class Table extends PureComponent {
                 height={tableHeight}
                 headerHeight={headerHeight}
                 rowClassName={this.rowClassName}
-                rowHeight={({ index }) => rowsHeight(data[index])}
+                rowHeight={({ index }) =>
+                  dynamicRowsHeight
+                    ? getDynamicRowHeight(index)
+                    : rowsHeight(index)}
                 rowCount={data.length}
                 sort={this.handleSortChange}
                 sortBy={sortBy}
@@ -280,7 +296,9 @@ Table.propTypes = {
   horizontalScroll: PropTypes.bool.isRequired,
   /* Array to order the column headers */
   // eslint-disable-next-line react/forbid-prop-types
-  firstColumnHeaders: PropTypes.array
+  firstColumnHeaders: PropTypes.array,
+  /* Boolean value to calculate dynamic rows */
+  dynamicRowsHeight: PropTypes.bool
 };
 
 Table.defaultProps = {
@@ -292,7 +310,8 @@ Table.defaultProps = {
   setColumnWidth: null,
   setRowsHeight: null,
   ellipsisColumns: [],
-  firstColumnHeaders: []
+  firstColumnHeaders: [],
+  dynamicRowsHeight: false
 };
 
 export default Table;

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -11,5 +11,6 @@ const ellipsisColumns = ["composite_name"];
   ellipsisColumns={ellipsisColumns}
   emptyValueLabel={'Not specified'}
   horizontalScroll
+  dynamicRowsHeight={true}
 />
 ```


### PR DESCRIPTION
This PR adds a dynamicRowsHeight prop to Table to allow calculating height of row based on the text inside.
When set to true each row is calculated separately and fits the text that is inside data.definition.
**Doubts**: data.definition is quite specific, maybe it is worth to do the logic in the project and pass the row height through setRowsHeight prop instead of passing dynamicRowsHeight prop. Tell me your thoughts.

![image](https://user-images.githubusercontent.com/6136899/47368524-b48a2600-d6d9-11e8-9bf8-64e46c86e019.png)

![image](https://user-images.githubusercontent.com/6136899/47368585-d388b800-d6d9-11e8-888f-502cb6621dc8.png)

Although there seems to be some weird bug that was already there;
![image](https://user-images.githubusercontent.com/6136899/47368691-fd41df00-d6d9-11e8-8139-293257c5f170.png)
^ this combination without selecting stackable seems to be causing columns cut

