### PR TITLE
Feature/sankey redesign

### DIFF
--- a/src/components/charts/sankey/sankey-link/sankey-link-component.jsx
+++ b/src/components/charts/sankey/sankey-link/sankey-link-component.jsx
@@ -1,22 +1,34 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { PropTypes } from 'prop-types';
 import styles from './sankey-link-styles.scss';
 
-function SankeyLink({ sourceX, sourceY, sourceControlX, targetX, targetY, targetControlX, linkWidth }) {
-  const minLinkWidth = 2;
-  return (
-    <path
-      className={styles.link}
-      d={`
-        M${sourceX},${sourceY}
-        C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}
-      `}
-      fill="none"
-      stroke="#333"
-      strokeWidth={linkWidth < minLinkWidth ? minLinkWidth : linkWidth}
-      strokeOpacity="0.2"
-    />
-  );
+class SankeyLink extends PureComponent {
+  constructor() {
+    super();
+    this.minLinkWidth = 2;
+    this.state = { hover: false };
+  }
+
+  render() {
+    const { sourceX, sourceY, sourceControlX, targetX, targetY, targetControlX, linkWidth } = this.props;
+    const { hover } = this.state;
+    const updatedLinkWidth = linkWidth < this.minLinkWidth ? this.minLinkWidth : linkWidth;
+    return (
+      <path
+        className={styles.link}
+        d={`
+          M${sourceX},${sourceY}
+          C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}
+        `}
+        fill="none"
+        stroke="#333"
+        strokeWidth={hover ? updatedLinkWidth + 2 : updatedLinkWidth}
+        onMouseEnter={() => this.setState({ hover: true })}
+        onMouseLeave={() => this.setState({ hover: false })}
+        strokeOpacity="0.2"
+      />
+    );
+  }
 }
 
 SankeyLink.propTypes = {

--- a/src/components/charts/sankey/sankey-link/sankey-link-component.jsx
+++ b/src/components/charts/sankey/sankey-link/sankey-link-component.jsx
@@ -3,6 +3,7 @@ import { PropTypes } from 'prop-types';
 import styles from './sankey-link-styles.scss';
 
 function SankeyLink({ sourceX, sourceY, sourceControlX, targetX, targetY, targetControlX, linkWidth }) {
+  const minLinkWidth = 2;
   return (
     <path
       className={styles.link}
@@ -12,7 +13,7 @@ function SankeyLink({ sourceX, sourceY, sourceControlX, targetX, targetY, target
       `}
       fill="none"
       stroke="#333"
-      strokeWidth={linkWidth}
+      strokeWidth={linkWidth < minLinkWidth ? minLinkWidth : linkWidth}
       strokeOpacity="0.2"
     />
   );

--- a/src/components/charts/sankey/sankey-link/sankey-link-component.jsx
+++ b/src/components/charts/sankey/sankey-link/sankey-link-component.jsx
@@ -10,15 +10,16 @@ class SankeyLink extends PureComponent {
   }
 
   render() {
-    const { sourceX, sourceY, sourceControlX, targetX, targetY, targetControlX, linkWidth } = this.props;
+    const { sourceX, sourceY, sourceControlX, targetX, targetY, targetControlX, linkWidth, config } = this.props;
     const { hover } = this.state;
     const updatedLinkWidth = linkWidth < this.minLinkWidth ? this.minLinkWidth : linkWidth;
+    const linkStart = config.titlePadding || 140;
     return (
       <path
         className={styles.link}
         d={`
-          M${sourceX},${sourceY}
-          C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}
+          M${sourceX + linkStart},${sourceY}
+          C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX - linkStart},${targetY}
         `}
         fill="none"
         stroke="#333"
@@ -38,7 +39,8 @@ SankeyLink.propTypes = {
   targetY: PropTypes.number,
   sourceControlX: PropTypes.number,
   targetControlX: PropTypes.number,
-  linkWidth: PropTypes.number
+  linkWidth: PropTypes.number,
+  config: PropTypes.object
 };
 
 SankeyLink.defaultProps = {
@@ -48,7 +50,8 @@ SankeyLink.defaultProps = {
   targetY: null,
   sourceControlX: null,
   targetControlX: null,
-  linkWidth: null
+  linkWidth: null,
+  config: null
 };
 
 export default SankeyLink;

--- a/src/components/charts/sankey/sankey-link/sankey-link-styles.scss
+++ b/src/components/charts/sankey/sankey-link/sankey-link-styles.scss
@@ -4,6 +4,7 @@
   cursor: pointer;
 
   &:hover {
+    stroke: #113750;
     stroke-opacity: 0.3;
   }
 }

--- a/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
+++ b/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
@@ -2,32 +2,61 @@ import React from 'react';
 import { Rectangle, Layer } from 'recharts';
 import { PropTypes } from 'prop-types';
 import { format } from 'd3-format';
+import { splitSVGText } from 'utils/utils';
 import styles from './sankey-node-styles.scss';
 
 function SankeyNode({ x, y, width, height, index, payload, config }) {
-  const padding = 20;
   const isOut = x > width;
-  const unit = config.unit ? `${config.unit} ` : '';
-  const suffix = config.suffix ? ` ${config.suffix}` : '';
+  const padding = config.padding || 20;
+  const rectangleStart = config.titlePadding || 140;
   const scale = config.scale || 1;
   const valueFormat = config.format || '~r';
+  const unit = config.unit ? `${config.unit} ` : '';
+  const suffix = config.suffix ? ` ${config.suffix}` : '';
+  const minHeight = 2;
+
+  const tSpans = (text) => {
+    const fontSize = config.fontSize || 13;
+    const lineHeight = config.lineHeigth || 1.2;
+    const textHeight = config.textHeight || 20;
+    const tspanLineHeight = config.tspanLineHeight || 10;
+    const startX = isOut ? x - rectangleStart + padding : x + width + rectangleStart - padding / 2;
+    const startY = y + (height / 2) - fontSize || 0;
+    const charactersPerLine = (rectangleStart / 6) - 3; // -3 for the ellipsis
+    const maxLines = 2;
+    return splitSVGText(text, textHeight, tspanLineHeight, charactersPerLine, maxLines).map((t, i) => (
+      `<tspan
+        x="${startX}"
+        y="${startY + fontSize * lineHeight + i * fontSize * lineHeight}"
+      >
+        ${t}
+      </tspan>`
+    )).join('\n');
+  }
   return (
     <Layer key={`CustomNode${index}`}>
+      <text
+        textAnchor={isOut ? 'start' : 'end'}
+        textLength={rectangleStart}
+        className={styles.nodeText}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: tSpans(payload.name) }}
+      />
       <Rectangle
-        x={x}
+        x={isOut ? x - rectangleStart : x + width + rectangleStart}
         y={y}
         width={width}
-        height={height}
+        height={height < minHeight ? minHeight : height}
         fill={payload.color}
         fillOpacity="1"
       />
       <text
         textAnchor={isOut ? 'end' : 'start'}
-        x={isOut ? x - padding : x + width + padding}
+        x={isOut ? x - (rectangleStart + padding) : x + width + (rectangleStart + padding)}
         y={y + height / 2}
         className={styles.nodeText}
       >
-        {`${payload.name}: ${unit}${format(valueFormat)(payload.value * scale)}${suffix}`}
+        {`${unit}${format(valueFormat)(payload.value * scale)}${suffix}`}
       </text>
     </Layer>
   );
@@ -55,7 +84,9 @@ SankeyNode.propTypes = {
   }),
   config: PropTypes.shape({
     unit: PropTypes.string,
-    suffix: PropTypes.string
+    suffix: PropTypes.string,
+    // Padding for the titles, before and after the chart
+    titlePadding: PropTypes.number
   })
 };
 

--- a/src/components/charts/sankey/sankey-styles.scss
+++ b/src/components/charts/sankey/sankey-styles.scss
@@ -1,5 +1,9 @@
 @import '~styles/settings.scss';
 
+.sankey > svg {
+  padding-bottom: 1em;
+}
+
 .link {
   cursor: pointer;
 

--- a/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
+++ b/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
@@ -56,7 +56,9 @@ class SankeyTooltip extends PureComponent {
                       {`${format(valueFormat)(node.value * scale)}${suffix}`}
                     </div>
                   </div>
-                  {tooltipChildren && tooltipChildren(node)}
+                  <div className={styles.tooltipChildren}>
+                    {tooltipChildren && tooltipChildren(node)}
+                  </div>
                 </div>
               ) : null
             )

--- a/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-styles.scss
+++ b/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-styles.scss
@@ -2,6 +2,9 @@
 
 .tooltip {
   background: $white;
+  font-family: $font-family-2;
+  letter-spacing: -0.1px;
+  font-size: $font-size-xs;
   min-width: 180px;
   max-width: 300px;
   padding: 15px;
@@ -18,7 +21,6 @@
 
 .unit {
   color: $dark-gray;
-  font-size: $font-size-s;
 }
 
 .label {
@@ -26,7 +28,6 @@
   flex-direction: row;
   justify-content: space-between;
   margin-bottom: 5px;
-  font-size: $font-size-sm;
 }
 
 .legend {
@@ -56,14 +57,15 @@
 }
 
 .targetName {
-  color: $dark-gray;
-  font-weight: bold;
-  font-size: $font-size-s;
+  color: $theme-color;
 }
 
 .focus {
   @extend .labelValue;
 
   margin-top: 10px;
-  font-size: $font-size-s;
+}
+
+.tooltipChildren {
+  color: $dark-gray;
 }

--- a/src/components/charts/sankey/sankey.js
+++ b/src/components/charts/sankey/sankey.js
@@ -4,6 +4,7 @@ import { Sankey, Tooltip, ResponsiveContainer } from 'recharts';
 import SankeyTooltip from './sankey-tooltip';
 import SankeyLink from './sankey-link';
 import SankeyNode from './sankey-node';
+import styles from './sankey-styles.scss';
 
 function SankeyChart(
   {
@@ -21,17 +22,25 @@ function SankeyChart(
   }
 ) {
   return (
-    <ResponsiveContainer width="100%" aspect={config.aspect || 16 / 9}>
+    <ResponsiveContainer width="100%" height={height}>
       <Sankey
         width={width}
-        height={height}
         data={data}
+        className={styles.sankey}
         nodeWidth={nodeWidth}
         nodePadding={nodePadding}
-        link={customLink || <SankeyLink />}
+        link={
+          customLink ||
+            <SankeyLink config={{ titlePadding: config.titlePadding }} />
+        }
         node={
           customNode ||
-            <SankeyNode containerWidth={containerWidth} config={config.node} />
+            (
+              <SankeyNode
+                containerWidth={containerWidth}
+                config={{ ...config.node, titlePadding: config.titlePadding }}
+              />
+            )
         }
       >
         {

--- a/src/components/charts/sankey/sankey.md
+++ b/src/components/charts/sankey/sankey.md
@@ -7,24 +7,49 @@ const data = {
       color: '#00955f'
     },
     {
-      name: 'France',
+      name: 'France, in Western Europe, encompasses medieval cities, alpine villages and Mediterranean beaches. Paris, its capital, is famed for its fashion houses, classical art museums including the Louvre and monuments like the Eiffel Tower',
       color: '#FFB400'
     },
     {
-      name: 'Loans',
+      name: 'Switzerland is a mountainous Central European country, home to numerous lakes, villages and the high peaks of the Alps. Its cities contain medieval quarters, with landmarks like capital Bern’s Zytglogge',
+      color: '#3498db'
+    },
+    {
+      name: 'Grants 2 are made to fund a specific project and require some level of compliance and reporting. The grant writing process involves an applicant submitting a proposal (or submission) to a potential funder, either on the applicants own initiative or in response to a Request for Proposal from the funder.',
+      color: '#00955f'
+    },
+    {
+      name: 'Loans is the lending of money by one or more individuals, organizations, and/or other entities to other individuals, organizations etc.',
+      color: '#FFB400'
+    },
+    {
+      name: 'Loans 2',
       color: '#3498db'
     },
     {
       name: 'Grants',
       color: '#FF7800'
+    },
+    {
+      name: 'Grants are made to fund a specific project and require some level of compliance and reporting. The grant writing process involves an applicant submitting a proposal (or submission) to a potential funder',
+      color: '#FF7800'
+    },
+    {
+      name: 'Grants are non-repayable funds or products disbursed or given by one party (grant makers), often a government department, corporation, foundation or trust',
+      color: '#FF73D0'
     }
   ],
   links: [
-    { source: 0, target: 2, value: 1000 },
+    { source: 0, target: 5, value: 1000 },
     { source: 0, target: 3, value: 940000 },
     { source: 1, target: 3, value: 150000 },
-    { source: 1, target: 3, value: 190000 },
-    { source: 0, target: 3, value: 5700000 }
+    { source: 1, target: 3, value: 10000 },
+    { source: 2, target: 3, value: 5700000 },
+    { source: 1, target: 4, value: 1190000 },
+    { source: 0, target: 5, value: 5700000 },
+    { source: 1, target: 6, value: 11190000 },
+    { source: 0, target: 7, value: 5700000 },
+    { source: 1, target: 8, value: 10 },
   ]
 };
 

--- a/src/components/charts/sankey/sankey.md
+++ b/src/components/charts/sankey/sankey.md
@@ -20,8 +20,8 @@ const data = {
     }
   ],
   links: [
-    { source: 0, target: 2, value: 240000 },
-    { source: 0, target: 2, value: 940000 },
+    { source: 0, target: 2, value: 1000 },
+    { source: 0, target: 3, value: 940000 },
     { source: 1, target: 3, value: 150000 },
     { source: 1, target: 3, value: 190000 },
     { source: 0, target: 3, value: 5700000 }

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -1,5 +1,6 @@
 // Font families
 $font-family-1: 'Lato', sans-serif;
+$font-family-2: 'Roboto Mono', sans-serif;
 
 // Font sizes
 $font-size-xs: 0.75rem; // 12px / 16px

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -50,3 +50,51 @@ export function getCustomTicks(
     ticks: getNiceTickValues([ minValue, maxValue ], tickNumber, decimals)
   };
 }
+
+// formats/create ellipsis nodes text using # of lines available, node width, etc
+export const splitSVGText = (
+  text,
+  height,
+  _labelCharHeight,
+  _labelCharsPerLine,
+  _labelMaxLines
+) =>
+  {
+    if (height < _labelCharHeight - 6) return '';
+    const maxLinesForNode = Math.max(
+      1,
+      Math.min(_labelMaxLines, Math.floor(height / _labelCharHeight))
+    );
+    const words = text.split(' ');
+    const lines = [];
+    let currentLine = '';
+
+    for (let i = 0; i < words.length; i++) {
+      const word = words[i];
+      let line = word;
+      if (currentLine.trim() !== '') {
+        line = `${currentLine} ${line} `;
+      }
+      // line is too long
+      if (line.length > _labelCharsPerLine) {
+        // last allowed line: show max length possible with ellipsis
+        if (lines.length === maxLinesForNode - 1) {
+          currentLine = `${line.substr(0, _labelCharsPerLine - 1)} …`;
+          break;
+        } else if (word.length > _labelCharsPerLine) {
+          // word longer than allowed line length: split word in two with a dash
+          const wordStart = line.substr(0, _labelCharsPerLine - 1);
+          currentLine = line.substr(_labelCharsPerLine - 1);
+          lines.push(`${wordStart} -`);
+        } else {
+          lines.push(currentLine);
+          currentLine = word;
+        }
+      } else {
+        currentLine = line;
+      }
+    }
+
+    lines.push(currentLine);
+    return lines;
+  };

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -12,7 +12,7 @@ module.exports = {
       links: [
         {
           rel: 'stylesheet',
-          href: 'https://fonts.googleapis.com/css?family=Lato:300,400,500,700'
+          href: 'https://fonts.googleapis.com/css?family=Lato:300,400,500,700|Roboto+Mono'
         }
       ]
     }


### PR DESCRIPTION
This PR redesigns the Sankey Chart:

- Min width of each link (so its visible) and add width when hovered
- Hover color to blue
- Legends in the nodes should be outside the chart in two columns with ellipsis if its longer than that
- Quantity and unit should remain inside the chart
- Align first texts to the right

![image](https://user-images.githubusercontent.com/9701591/47372156-7a288500-d6e9-11e8-95c1-9be3106ce91d.png)
