### PR TITLE
Implement display of multiple text lines in tooltip in bubble-charts

### DIFF
--- a/src/components/charts/bubble-chart/bubble-chart-styles.scss
+++ b/src/components/charts/bubble-chart/bubble-chart-styles.scss
@@ -1,3 +1,7 @@
 .circle {
   cursor: pointer;
 }
+
+.textAlignLeft span {
+  text-align: left !important;
+}

--- a/src/components/charts/bubble-chart/bubble-chart-styles.scss
+++ b/src/components/charts/bubble-chart/bubble-chart-styles.scss
@@ -2,6 +2,6 @@
   cursor: pointer;
 }
 
-.textAlignLeft span {
+.tooltip span {
   text-align: left !important;
 }

--- a/src/components/charts/bubble-chart/bubble-chart.js
+++ b/src/components/charts/bubble-chart/bubble-chart.js
@@ -64,7 +64,7 @@ class BubbleChart extends PureComponent {
         <ReactTooltip
           place="left"
           id="chartTooltip"
-          className={cx(tooltipClassName, styles.textAlignLeft)}
+          className={cx(styles.tooltip, tooltipClassName)}
           multiline
         />
       </Fragment>

--- a/src/components/charts/bubble-chart/bubble-chart.js
+++ b/src/components/charts/bubble-chart/bubble-chart.js
@@ -25,6 +25,11 @@ class BubbleChart extends PureComponent {
     return bubble(root);
   };
 
+  getTooltipText = ({ tooltipContent, value, unit }) =>
+    tooltipContent && tooltipContent.length
+      ? tooltipContent.join('<br>')
+      : `${value} ${unit}`;
+
   render() {
     const {
       width,
@@ -48,7 +53,7 @@ class BubbleChart extends PureComponent {
                 <circle
                   r={d.r}
                   data-for="chartTooltip"
-                  data-tip={`${d.data.value} ${d.data.unit}`}
+                  data-tip={this.getTooltipText(d.data)}
                   fill={d.data.color}
                   className={cx(styles.circle, theme.circle)}
                 />
@@ -59,7 +64,8 @@ class BubbleChart extends PureComponent {
         <ReactTooltip
           place="left"
           id="chartTooltip"
-          className={tooltipClassName}
+          className={cx(tooltipClassName, styles.textAlignLeft)}
+          multiline
         />
       </Fragment>
     );
@@ -79,6 +85,7 @@ BubbleChart.propTypes = {
       value: PropTypes.number,
       unit: PropTypes.string,
       id: PropTypes.number,
+      tooltipContent: PropTypes.arrayOf(PropTypes.string),
       /** Color prop accepts any valid color string on the svg spec
        * (HEX, RGB, RGBa, HSL, HSLa, named colors) */
       color: PropTypes.string

--- a/src/components/charts/bubble-chart/bubble-chart.md
+++ b/src/components/charts/bubble-chart/bubble-chart.md
@@ -4,8 +4,8 @@ const styles = require('./bubble-chart-styles.scss');
 const width = 400;
 const height = 400;
 const  data = [
-    {id:1, value: 1000, unit: 'MtCO2', color: '#28965A'},
-    {id:2, value: 5700, unit: 'MtCO2', color: '#28965A'},
+    {id:1, value: 1000, unit: 'MtCO2', tooltipContent: ['First line', '1000 MtCO2', 'Third line'], color: '#28965A'},
+    {id:2, value: 5700, unit: 'MtCO2', tooltipContent: [], color: '#28965A'},
     {id:3, value: 89, unit: 'MtCO2', color: '#28965A'},
     {id:4, value: 54, unit: 'MtCO2', color: '#28965A'},
     {id:5, value: 330, unit: 'MtCO2', color: '#28965A'},


### PR DESCRIPTION
- Added new prop `tooltipContent` to bubble-chart data to enable setting customized tooltip content; it's passed as an array of strings so multilines are possible: each item in array represents new line in a tooltip. If `tooltipContent` is not passed or is an empty array it renders value + unit
- If multiline align to the left

![bubble-chart](https://user-images.githubusercontent.com/15097138/48265040-5ec8b400-e423-11e8-87b1-c2d8edeb868c.png)
