### PR TITLE
Add format value feature to bubble chart

### DIFF
--- a/src/components/charts/bubble-chart/bubble-chart-styles.scss
+++ b/src/components/charts/bubble-chart/bubble-chart-styles.scss
@@ -1,7 +1,29 @@
+@import '~styles/settings.scss';
+
 .circle {
   cursor: pointer;
 }
 
-.tooltip span {
-  text-align: left !important;
+:global {
+  .bubbleChartTooltip {
+    font-family: $font-family-1;
+    padding: 15px;
+    font-size: $font-size-xs;
+    letter-spacing: -0.1px;
+    box-shadow: 0 5px 15px 0 rgba(17, 55, 80, 0.15);
+    max-width: 300px;
+
+    &.__react_component_tooltip.type-dark {
+      color: $theme-color;
+      background-color: $white;
+    }
+
+    & .multi-line {
+      text-align: left;
+    }
+
+    &::after { // Hides the arrow
+      display: none;
+    }
+  }
 }

--- a/src/components/charts/bubble-chart/bubble-chart-styles.scss
+++ b/src/components/charts/bubble-chart/bubble-chart-styles.scss
@@ -18,6 +18,10 @@
       background-color: $white;
     }
 
+    &.__react_component_tooltip.show {
+      opacity: 1;
+    }
+
     & .multi-line {
       text-align: left;
     }

--- a/src/components/charts/bubble-chart/bubble-chart.js
+++ b/src/components/charts/bubble-chart/bubble-chart.js
@@ -74,7 +74,7 @@ class BubbleChart extends PureComponent {
         <ReactTooltip
           place="left"
           id="chartTooltip"
-          className={cx(styles.tooltip, tooltipClassName)}
+          className={cx('bubbleChartTooltip', tooltipClassName)}
           multiline
         />
       </Fragment>
@@ -114,7 +114,7 @@ BubbleChart.propTypes = {
 
 BubbleChart.defaultProps = {
   theme: {},
-  tooltipClassName: 'bubbleChartTooltip',
+  tooltipClassName: '',
   config: PropTypes.shape({ scale: 1, suffix: '', format: '~r' })
 };
 

--- a/src/components/charts/bubble-chart/bubble-chart.js
+++ b/src/components/charts/bubble-chart/bubble-chart.js
@@ -2,6 +2,7 @@ import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
 import { pack, hierarchy } from 'd3-hierarchy';
+import { format } from 'd3-format';
 import cx from 'classnames';
 import styles from './bubble-chart-styles.scss';
 
@@ -25,10 +26,18 @@ class BubbleChart extends PureComponent {
     return bubble(root);
   };
 
-  getTooltipText = ({ tooltipContent, value, unit }) =>
-    tooltipContent && tooltipContent.length
-      ? tooltipContent.join('<br>')
-      : `${value} ${unit}`;
+  formatValue = (value, unit, { scale, suffix, format: f }) =>
+    `${format(f)(value * scale)}${suffix} ${unit}`;
+
+  getTooltipText = ({ tooltipContent, value, unit }, config) => {
+    if (tooltipContent && tooltipContent.length) {
+      const formattedContent = tooltipContent.map(
+        v => typeof v === 'number' ? this.formatValue(v, unit, config) : v
+      );
+      return formattedContent.join('<br>');
+    }
+    return this.formatValue(value, unit, config);
+  };
 
   render() {
     const {
@@ -37,7 +46,8 @@ class BubbleChart extends PureComponent {
       handleNodeClick,
       data,
       tooltipClassName,
-      theme
+      theme,
+      config
     } = this.props;
     const charData = data && this.chartDataCalculation(width, data);
     return (
@@ -53,7 +63,7 @@ class BubbleChart extends PureComponent {
                 <circle
                   r={d.r}
                   data-for="chartTooltip"
-                  data-tip={this.getTooltipText(d.data)}
+                  data-tip={this.getTooltipText(d.data, config)}
                   fill={d.data.color}
                   className={cx(styles.circle, theme.circle)}
                 />
@@ -83,14 +93,20 @@ BubbleChart.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.number,
-      unit: PropTypes.string,
       id: PropTypes.number,
-      tooltipContent: PropTypes.arrayOf(PropTypes.string),
+      tooltipContent: PropTypes.arrayOf(
+        PropTypes.oneOfType([ PropTypes.string, PropTypes.number ])
+      ),
       /** Color prop accepts any valid color string on the svg spec
        * (HEX, RGB, RGBa, HSL, HSLa, named colors) */
       color: PropTypes.string
     })
   ).isRequired,
+  config: PropTypes.shape({
+    scale: PropTypes.number,
+    suffix: PropTypes.string,
+    format: PropTypes.string
+  }),
   tooltipClassName: PropTypes.string,
   /** Theming circles with customized styles */
   theme: PropTypes.shape({ circle: PropTypes.string })
@@ -98,7 +114,8 @@ BubbleChart.propTypes = {
 
 BubbleChart.defaultProps = {
   theme: {},
-  tooltipClassName: 'bubbleChartTooltip'
+  tooltipClassName: 'bubbleChartTooltip',
+  config: PropTypes.shape({ scale: 1, suffix: '', format: '~r' })
 };
 
 export default BubbleChart;

--- a/src/components/charts/bubble-chart/bubble-chart.md
+++ b/src/components/charts/bubble-chart/bubble-chart.md
@@ -3,16 +3,22 @@
 const styles = require('./bubble-chart-styles.scss');
 const width = 400;
 const height = 400;
-const  data = [
-    {id:1, value: 1000, unit: 'MtCO2', tooltipContent: ['First line', '1000 MtCO2', 'Third line'], color: '#28965A'},
-    {id:2, value: 5700, unit: 'MtCO2', tooltipContent: [], color: '#28965A'},
-    {id:3, value: 89, unit: 'MtCO2', color: '#28965A'},
-    {id:4, value: 54, unit: 'MtCO2', color: '#28965A'},
-    {id:5, value: 330, unit: 'MtCO2', color: '#28965A'},
-    {id:6, value: 9, unit: 'MtCO2', color: '#28965A'},
-    {id:7, value: 320, unit: 'MtCO2', color: '#28965A'},
-    {id:8, value: 76, unit: 'MtCO2', color: '#28965A'}
+const data = [
+    {id:1, value: 10000, unit: 'MtCO2', tooltipContent: ['First line', 10000, 'Third line'], color: '#28965A'},
+    {id:2, value: 57000, unit: 'MtCO2', tooltipContent: [], color: '#28965A'},
+    {id:3, value: 890, unit: 'MtCO2', color: '#28965A'},
+    {id:4, value: 540, unit: 'MtCO2', color: '#28965A'},
+    {id:5, value: 3300, unit: 'MtCO2', color: '#28965A'},
+    {id:6, value: 90, unit: 'MtCO2', color: '#28965A'},
+    {id:7, value: 3200, unit: 'MtCO2', color: '#28965A'},
+    {id:8, value: 760, unit: 'MtCO2', color: '#28965A'}
   ];
+
+const config = {
+  scale: 1/1000,
+  suffix: 'k',
+  format: '~r'
+};
 
 <BubbleChart
   styles={styles}
@@ -20,5 +26,6 @@ const  data = [
   height={height}
   data={data}
   handleNodeClick={(e, id) => console.info(`Clicked on element with id: ${id}`)}
+  config={config}
 />
 ```


### PR DESCRIPTION
- Add ability to format value in bubble chart by passing a config object (like in sankey chart)
- A value passed in `tooltipContent` has to be a number if you want to format it
![formating value bubble chart](https://user-images.githubusercontent.com/15097138/48343912-8dd16680-e66b-11e8-8de2-c1fe7c191722.png)
