### PR TITLE
Add hideResetButton prop to icon dropdown

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -30,6 +30,7 @@ class Dropdown extends PureComponent {
       infoText,
       required,
       optional,
+      hideResetButton,
       value,
       options,
       icons
@@ -93,6 +94,7 @@ class Dropdown extends PureComponent {
                     theme={{ icon: styles.iconValue }}
                   />
                 )}
+                hideResetButton={hideResetButton}
               />
 ) : (
   <SimpleSelect
@@ -129,6 +131,7 @@ Dropdown.propTypes = {
   withDot: PropTypes.bool,
   required: PropTypes.bool,
   optional: PropTypes.bool,
+  hideResetButton: PropTypes.bool,
   theme: PropTypes.shape({
     wrapper: PropTypes.string,
     dot: PropTypes.string,
@@ -148,6 +151,7 @@ Dropdown.defaultProps = {
   theme: {},
   loading: false,
   disabled: false,
+  hideResetButton: false,
   withDot: false,
   required: false,
   optional: false,

--- a/src/components/dropdown/dropdown.md
+++ b/src/components/dropdown/dropdown.md
@@ -74,8 +74,8 @@ const onValueChange = (selected) => {
     value={icons[state.selected.value]}
     options={state.data}
     onValueChange={onValueChange}
-    iconsDropdown
     icons={icons}
+    hideResetButton
   />
 </div>
 ```


### PR DESCRIPTION
Added missing hideResetButton prop to icon dropdown and updated docs

![image](https://user-images.githubusercontent.com/9701591/48479794-a1fe9a80-e808-11e8-9880-2cff2385ddfc.png)

