### PR TITLE
Fix deafult prop types for config object in bubble-chart

### DIFF
--- a/src/components/charts/bubble-chart/bubble-chart.js
+++ b/src/components/charts/bubble-chart/bubble-chart.js
@@ -115,7 +115,7 @@ BubbleChart.propTypes = {
 BubbleChart.defaultProps = {
   theme: {},
   tooltipClassName: '',
-  config: PropTypes.shape({ scale: 1, suffix: '', format: '~r' })
+  config: { scale: 1, suffix: '', format: '~r' }
 };
 
 export default BubbleChart;


### PR DESCRIPTION
- Fix default prop type for `config` property