### PR TITLE
Fix/sankey chart funder/financial flow tooltip

### DIFF
--- a/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
+++ b/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Rectangle, Layer } from 'recharts';
 import { PropTypes } from 'prop-types';
-import { format } from 'd3-format';
 import { splitSVGText } from 'utils/utils';
 import styles from './sankey-node-styles.scss';
 
@@ -9,10 +8,6 @@ function SankeyNode({ x, y, width, height, index, payload, config }) {
   const isOut = x > width;
   const padding = config.padding || 20;
   const rectangleStart = config.titlePadding || 140;
-  const scale = config.scale || 1;
-  const valueFormat = config.format || '~r';
-  const unit = config.unit ? `${config.unit} ` : '';
-  const suffix = config.suffix ? ` ${config.suffix}` : '';
   const minHeight = 2;
 
   const tSpans = (text) => {
@@ -50,14 +45,6 @@ function SankeyNode({ x, y, width, height, index, payload, config }) {
         fill={payload.color}
         fillOpacity="1"
       />
-      <text
-        textAnchor={isOut ? 'end' : 'start'}
-        x={isOut ? x - (rectangleStart + padding) : x + width + (rectangleStart + padding)}
-        y={y + height / 2}
-        className={styles.nodeText}
-      >
-        {`${unit}${format(valueFormat)(payload.value * scale)}${suffix}`}
-      </text>
     </Layer>
   );
 }

--- a/src/components/charts/sankey/sankey-styles.scss
+++ b/src/components/charts/sankey/sankey-styles.scss
@@ -4,6 +4,10 @@
   padding-bottom: 1em;
 }
 
+.sankey * {
+  font-family: $font-family-1;
+}
+
 .link {
   cursor: pointer;
 

--- a/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
+++ b/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
@@ -50,7 +50,7 @@ class SankeyTooltip extends PureComponent {
                         {node.payload.payload && node.payload.payload.source ? (
                           node.payload.payload.source.name
                         ) : (
-                          node.name
+                          node.payload.payload && node.payload.payload.name
                         )}
                       </div>
                     </div>

--- a/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
+++ b/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
@@ -56,6 +56,9 @@ class SankeyTooltip extends PureComponent {
                       {`${format(valueFormat)(node.value * scale)}${suffix}`}
                     </div>
                   </div>
+                  <div className={styles.labelValue}>
+                    {node.payload.payload && node.payload.payload.name}
+                  </div>
                   <div className={styles.tooltipChildren}>
                     {tooltipChildren && tooltipChildren(node)}
                   </div>

--- a/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
+++ b/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
@@ -38,26 +38,25 @@ class SankeyTooltip extends PureComponent {
                     <div className={styles.legend}>
                       <span
                         className={styles.labelDot}
-                        style={{
-                          backgroundColor: node.payload.payload &&
-                            node.payload.payload.source &&
+                        style={node.payload.payload && 
+                          {backgroundColor: node.payload.payload.source ? (
                             node.payload.payload.source.color
-                        }}
+                          ) : (
+                            node.payload.payload.color
+                          )}
+                        }
                       />
                       <div className={styles.labelName}>
-                        {
-                          node.payload.payload &&
-                            node.payload.payload.source &&
-                            node.payload.payload.source.name
-                        }
+                        {node.payload.payload && node.payload.payload.source ? (
+                          node.payload.payload.source.name
+                        ) : (
+                          node.name
+                        )}
                       </div>
                     </div>
                     <div className={styles.labelValue}>
                       {`${format(valueFormat)(node.value * scale)}${suffix}`}
                     </div>
-                  </div>
-                  <div className={styles.labelValue}>
-                    {node.payload.payload && node.payload.payload.name}
                   </div>
                   <div className={styles.tooltipChildren}>
                     {tooltipChildren && tooltipChildren(node)}

--- a/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-styles.scss
+++ b/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-styles.scss
@@ -53,7 +53,7 @@
 .labelValue {
   color: $dark-gray;
   text-align: right;
-  min-width: 45px;
+  min-width: max-content;
 }
 
 .targetName {

--- a/src/components/charts/sankey/sankey.md
+++ b/src/components/charts/sankey/sankey.md
@@ -67,7 +67,6 @@ const config = {
       scale: 1/100000,
       suffix: 'm',
       unit: 'USD million'
-
     },
   node:
     {

--- a/src/components/charts/sankey/sankey.md
+++ b/src/components/charts/sankey/sankey.md
@@ -65,7 +65,9 @@ const config = {
   tooltip:
     {
       scale: 1/100000,
-      suffix: 'm'
+      suffix: 'm',
+      unit: 'USD million'
+
     },
   node:
     {
@@ -74,5 +76,5 @@ const config = {
     }
 };
 
-<SankeyChart data={data} config={config} tooltipChildren={node => <div>Tooltip Extra Info: {node.name}</div>} />
+<SankeyChart data={data} config={config} tooltipChildren={node => <div>Tooltip Extra Info: extra info here</div>} />
 ```


### PR DESCRIPTION
- Change the style of the funder tooltip and financial flow tooltip: now display funder/flow name and the dot in this tooltip,
- Remove total amount from the flow on the chart, right now the amount is visible only in tooltips,
- Set `Lato` as default font of sankey chart elements,
![screenshot from 2018-11-15 11-41-01](https://user-images.githubusercontent.com/15097138/48550782-97590980-e8cb-11e8-9e73-73192d715ecd.png)
- Small fix for amount suffix: in some cases, suffix character was moving to the second line like that:
![bug-tooltip](https://user-images.githubusercontent.com/15097138/48548336-9e304e00-e8c4-11e8-86bc-abfbf4bb2cb1.png)
