### PR TITLE
Fix/sankey chart tooltip timeframes field

### DIFF
--- a/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
+++ b/src/components/charts/sankey/sankey-tooltip/sankey-tooltip-component.jsx
@@ -20,10 +20,10 @@ class SankeyTooltip extends PureComponent {
                 <div key={node.name}>
                   <div className={styles.tooltipHeader}>
                     <span className={styles.targetName}>
-                      {
-                        node.payload.payload &&
-                          node.payload.payload.target &&
-                          node.payload.payload.target.name
+                      {node.payload.payload && 
+                        node.payload.payload.target &&
+                          `${ node.payload.payload.target.name } 
+                           ${ node.payload.payload.timeframes ? node.payload.payload.timeframes : "" }`
                       }
                     </span>
                     {config.unit &&

--- a/src/components/charts/sankey/sankey.md
+++ b/src/components/charts/sankey/sankey.md
@@ -44,16 +44,16 @@ const data = {
     },
   ],
   links: [
-    { source: 0, target: 5, value: 1000 },
-    { source: 0, target: 3, value: 940000 },
-    { source: 1, target: 3, value: 150000 },
+    { source: 0, target: 5, value: 1000, timeframes: '2010-2014'},
+    { source: 0, target: 3, value: 940000, timeframes: '2012-2014' },
+    { source: 1, target: 3, value: 150000, timeframes: '2010-2013' },
     { source: 1, target: 3, value: 10000 },
     { source: 2, target: 3, value: 5700000 },
-    { source: 1, target: 4, value: 1190000 },
-    { source: 0, target: 5, value: 5700000 },
-    { source: 1, target: 6, value: 11190000 },
-    { source: 0, target: 7, value: 5700000 },
-    { source: 1, target: 8, value: 10 },
+    { source: 1, target: 4, value: 1190000, timeframes: '2011-2014' },
+    { source: 0, target: 5, value: 5700000, timeframes: '2013-2014' },
+    { source: 1, target: 6, value: 11190000, timeframes: '2010-2014' },
+    { source: 0, target: 7, value: 5700000, timeframes: '2011-2014' },
+    { source: 1, target: 8, value: 10, timeframes: '2010-2014' },
   ]
 };
 


### PR DESCRIPTION
- Add ability to display `timeframes` field, next to financial flow name:
![screenshot from 2018-11-15 18-24-36](https://user-images.githubusercontent.com/15097138/48573397-018da080-e904-11e8-904a-25f9cac3f393.png)
