### PR TITLE
Add padding to carousel paging

### DIFF
--- a/src/components/carousel/carousel-styles.scss
+++ b/src/components/carousel/carousel-styles.scss
@@ -17,7 +17,6 @@ $bottom-padding: 16px;
     li {
       list-style: none;
       cursor: pointer;
-      padding: 0 30px $bottom-padding;
       border-bottom: 3px solid rgba(10, 25, 65, 0.2);
 
       &:first-child {
@@ -57,6 +56,7 @@ $bottom-padding: 16px;
 
 .pagingTitle {
   position: relative;
+  padding: 0 30px $bottom-padding;
 }
 
 .pagingTitle::after {
@@ -64,7 +64,7 @@ $bottom-padding: 16px;
   width: 100%;
   height: 2px;
   position: absolute;
-  bottom: calc(-#{$bottom-padding} - 2px);
+  bottom: -2px;
   left: 0;
   background-color: transparent;
 }


### PR DESCRIPTION
This PR adds a padding around carousel paging titles to allow user to click them 
easier.
Quick fix to address a comment on [this](https://github.com/ClimateWatch-Vizzuality/indonesia-platform/pull/12) Indonesia platform PR

![kapture 2018-11-16 at 9 00 10](https://user-images.githubusercontent.com/6906348/48605811-1d358d00-e97e-11e8-9166-caedec3230cd.gif)