### PR TITLE
Avoid slide change on focus

### DIFF
--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -39,7 +39,6 @@ class Carousel extends Component {
       pauseOnHover: true,
       pauseOnDotsHover: true,
       pauseOnFocus: true,
-      focusOnSelect: true,
       dots: hasPaging,
       dotsClass: 'cwCarouselPaging',
       speed: 500,


### PR DESCRIPTION
This PR avoids slide change when clicking over a slide (on focus)