### PR TITLE
Fix/dropdown icon multiselect

### DIFF
--- a/src/components/charts/chart/chart.js
+++ b/src/components/charts/chart/chart.js
@@ -142,10 +142,8 @@ Chart.propTypes = {
         PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })
       )
     ),
-    projectedColumns: PropTypes.objectOf(
-      PropTypes.arrayOf(
-        PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })
-      )
+    projectedColumns: PropTypes.arrayOf(
+      PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })
     ),
     /** Custom icons might be passed with the stroke and fill */
     theme: PropTypes.objectOf(

--- a/src/components/charts/pie-chart/pie-chart.js
+++ b/src/components/charts/pie-chart/pie-chart.js
@@ -79,7 +79,7 @@ class PieChart extends PureComponent {
               isAnimationActive={config.animation || false}
               legendType="circle"
             >
-              {data.map(d => <Cell fill={getColor(d, config)} />)}
+              {data.map(d => <Cell key={d.name} fill={getColor(d, config)} />)}
             </Pie>
           </RechartsPieChart>
         </ResponsiveContainer>

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -95,6 +95,7 @@ class Dropdown extends PureComponent {
                   />
                 )}
                 hideResetButton={hideResetButton}
+                {...this.props}
               />
 ) : (
   <SimpleSelect

--- a/src/components/dropdown/dropdown.md
+++ b/src/components/dropdown/dropdown.md
@@ -60,18 +60,18 @@ const icons = {
 'area': arrowIcon.default,
 'bubble': infoIcon.default
 }
-
 initialState = {
   selected: data[0],
   data: data
 }
+
 const onValueChange = (selected) => {
   setState({ selected })
 }
 <div>
   <Dropdown
     theme={{ wrapper: theme.iconDropdownWrapper}}
-    value={icons[state.selected.value]}
+    value={state.selected}
     options={state.data}
     onValueChange={onValueChange}
     icons={icons}

--- a/src/components/multiselect/multiselect.js
+++ b/src/components/multiselect/multiselect.js
@@ -47,9 +47,13 @@ class Multiselect extends Component {
       );
     }
     if (hasValues && !search) {
-      return values.length === options && options.length
-        ? <span> All selected </span>
-        : <span> {`${values.length} selected`} </span>;
+      if (values.length === options && options.length)
+        return <span> All selected </span>;
+      return values.length === 1 ? values[0].label : (
+        <span>
+          {`${values.length} selected`}
+        </span>
+);
     }
     return null;
   }


### PR DESCRIPTION
- Fix icons dropdown adding all the props to the dropdown. There was a problem with the example
![image](https://user-images.githubusercontent.com/9701591/48616704-afe12680-e994-11e8-8ae0-8942c4f55dae.png)
- Show selected option if only one option is selected in multiselect
![image](https://user-images.githubusercontent.com/9701591/48616691-a48dfb00-e994-11e8-9f04-19198ad347f2.png)
- Fix some warnings
