### PR TITLE
Fix/projected data and legend

### DIFF
--- a/src/components/charts/projected-data/projected-data.js
+++ b/src/components/charts/projected-data/projected-data.js
@@ -32,7 +32,7 @@ const ProjectedData = (
 
         // LABELS
         // yearLabel
-        const LENGHT_LIMIT = config.projectedLabel.lengthLimit || 10;
+        const LENGHT_LIMIT = config.projectedLabel.lenghtLimit || 10;
         const isLongLabel = point.label.length > LENGHT_LIMIT;
         const yearLabel = (
           <Label

--- a/src/components/multiselect/multiselect.js
+++ b/src/components/multiselect/multiselect.js
@@ -144,9 +144,13 @@ class Multiselect extends Component {
             { [styles.searchable]: !icon }
           )}
         >
-          <div className={cx(styles.values, 'values')}>
-            {this.getSelectorValue()}
-          </div>
+          {
+            !icon && (
+            <div className={cx(styles.values, 'values')}>
+              {this.getSelectorValue()}
+            </div>
+              )
+          }
           {loading && <Loading className={styles.loader} mini />}
           <SelectizeMultiSelect
             ref={el => {

--- a/src/components/no-content/no-content.md
+++ b/src/components/no-content/no-content.md
@@ -1,3 +1,3 @@
 ```js
-<NoContent message="Something happen here" icon />
+<NoContent message="Something happened here" icon />
 ```


### PR DESCRIPTION
- FIx typo in projected data that was breaking the chart
- Don't show Extra text on legend if only one option selected
Problem:
![image](https://user-images.githubusercontent.com/9701591/48785816-c9140b00-ece5-11e8-9f1d-30228680d480.png)
