### PR TITLE
Fix/sankey chart text improvements

### DIFF
--- a/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
+++ b/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
@@ -19,15 +19,17 @@ function SankeyNode({ x, y, width, height, index, payload, config }) {
     const startY = y + (height / 2) - fontSize || 0;
     const charactersPerLine = (rectangleStart / 6) - 3; // -3 for the ellipsis
     const maxLines = 2;
-    return splitSVGText(text, textHeight, tspanLineHeight, charactersPerLine, maxLines).map((t, i) => (
+    const splittedSVGText = splitSVGText(text, textHeight, tspanLineHeight, charactersPerLine, maxLines);
+    return splittedSVGText.map((t, i) => (
       `<tspan
         x="${startX}"
-        y="${startY + fontSize * lineHeight + i * fontSize * lineHeight}"
+        y="${startY + fontSize * lineHeight + i * fontSize * lineHeight - (0.5 * (splittedSVGText.length - 1)) * fontSize}"
       >
         ${t}
       </tspan>`
     )).join('\n');
   }
+
   return payload && payload.value && (
     <Layer key={`CustomNode${index}`}>
       <text

--- a/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
+++ b/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
@@ -19,11 +19,11 @@ function SankeyNode({ x, y, width, height, index, payload, config }) {
     const startY = y + (height / 2) - fontSize || 0;
     const charactersPerLine = (rectangleStart / 6) - 3; // -3 for the ellipsis
     const maxLines = 2;
-    const splittedSVGText = splitSVGText(text, textHeight, tspanLineHeight, charactersPerLine, maxLines);
-    return splittedSVGText.map((t, i) => (
+    const svgTexts = splitSVGText(text, textHeight, tspanLineHeight, charactersPerLine, maxLines);
+    return svgTexts.map((t, i) => (
       `<tspan
         x="${startX}"
-        y="${startY + fontSize * lineHeight + i * fontSize * lineHeight - (0.5 * (splittedSVGText.length - 1)) * fontSize}"
+        y="${startY + fontSize * lineHeight + i * fontSize * lineHeight - (0.5 * (svgTexts.length - 1)) * fontSize}"
       >
         ${t}
       </tspan>`

--- a/src/components/charts/sankey/sankey.js
+++ b/src/components/charts/sankey/sankey.js
@@ -18,7 +18,8 @@ function SankeyChart(
     customTooltip,
     customLink,
     customNode,
-    tooltipChildren
+    tooltipChildren,
+    margin
   }
 ) {
   return (
@@ -29,6 +30,7 @@ function SankeyChart(
         className={styles.sankey}
         nodeWidth={nodeWidth}
         nodePadding={nodePadding}
+        margin={margin}
         link={
           customLink ||
             <SankeyLink config={{ titlePadding: config.titlePadding }} />
@@ -91,6 +93,13 @@ SankeyChart.propTypes = {
     node: PropTypes.object,
     /** Configuration for the aspect of the responsive container */
     aspect: PropTypes.number
+  }),
+  /** Set margin of sankey component, used to calculate a position of all child elements inside sankey charts  */
+  margin: PropTypes.shape({
+    top: PropTypes.number,
+    right: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number
   })
 };
 
@@ -105,7 +114,8 @@ SankeyChart.defaultProps = {
   customTooltip: null,
   customLink: null,
   customNode: null,
-  tooltipChildren: null
+  tooltipChildren: null,
+  margin: { top: 10 }
 };
 
 export default SankeyChart;

--- a/src/components/charts/sankey/sankey.md
+++ b/src/components/charts/sankey/sankey.md
@@ -15,6 +15,10 @@ const data = {
       color: '#3498db'
     },
     {
+      name: 'Portugal',
+      color: '#ab0000'
+    },
+    {
       name: 'Grants 2 are made to fund a specific project and require some level of compliance and reporting. The grant writing process involves an applicant submitting a proposal (or submission) to a potential funder, either on the applicants own initiative or in response to a Request for Proposal from the funder.',
       color: '#00955f'
     },
@@ -44,16 +48,16 @@ const data = {
     },
   ],
   links: [
-    { source: 0, target: 5, value: 1000, timeframes: '2010-2014'},
-    { source: 0, target: 3, value: 940000, timeframes: '2012-2014' },
-    { source: 1, target: 3, value: 150000, timeframes: '2010-2013' },
-    { source: 1, target: 3, value: 10000 },
-    { source: 2, target: 3, value: 5700000 },
-    { source: 1, target: 4, value: 1190000, timeframes: '2011-2014' },
-    { source: 0, target: 5, value: 5700000, timeframes: '2013-2014' },
-    { source: 1, target: 6, value: 11190000, timeframes: '2010-2014' },
-    { source: 0, target: 7, value: 5700000, timeframes: '2011-2014' },
-    { source: 1, target: 8, value: 10, timeframes: '2010-2014' },
+    { source: 0, target: 6, value: 1000, timeframes: '2010-2014'},
+    { source: 0, target: 4, value: 940000, timeframes: '2012-2014' },
+    { source: 1, target: 4, value: 150000 },
+    { source: 2, target: 4, value: 5700000 },
+    { source: 1, target: 5, value: 1190000, timeframes: '2011-2014' },
+    { source: 0, target: 6, value: 5700000, timeframes: '2013-2014' },
+    { source: 1, target: 7, value: 11190000, timeframes: '2010-2014' },
+    { source: 0, target: 8, value: 5700000, timeframes: '2011-2014' },
+    { source: 1, target: 9, value: 10, timeframes: '2010-2014' },
+    { source: 3, target: 9, value: 9092312, timeframes: '2010-2014' }
   ]
 };
 


### PR DESCRIPTION
In reference to this task: https://www.pivotaltracker.com/story/show/161930807
- Fix clipped text of the first label in sankey chart - prop `margin` in sankey can add some space on the top/right/bottom/left of the chart,
-  Improve vertical centering of node labels by modifying the calculation in sankey-node,
- Add new `source` to sankey.md file,
![untitled](https://user-images.githubusercontent.com/15097138/48851818-e0b1c900-eda3-11e8-87e4-693f4bff3e32.png)
