### PR TITLE
Add barSize prop to bar chart for defining width of a single bar

### DIFF
--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -42,7 +42,8 @@ class SimpleBarChart extends PureComponent {
       customXAxisTick,
       customYAxisTick,
       customTooltip,
-      getCustomYLabelFormat
+      getCustomYLabelFormat,
+      barSize
     } = this.props;
     const unit = showUnit &&
       config &&
@@ -112,6 +113,7 @@ class SimpleBarChart extends PureComponent {
               <Bar
                 key={dataKey}
                 dataKey={dataKey}
+                barSize={barSize}
                 fill={config.theme[dataKey] && config.theme[dataKey].fill}
               />
             ))}
@@ -134,7 +136,8 @@ SimpleBarChart.propTypes = {
   customXAxisTick: PropTypes.node,
   customYAxisTick: PropTypes.node,
   customTooltip: PropTypes.node,
-  getCustomYLabelFormat: PropTypes.func
+  getCustomYLabelFormat: PropTypes.func,
+  barSize: PropTypes.number
 };
 
 SimpleBarChart.defaultProps = {
@@ -150,7 +153,8 @@ SimpleBarChart.defaultProps = {
   customXAxisTick: null,
   customYAxisTick: null,
   customTooltip: null,
-  getCustomYLabelFormat: null
+  getCustomYLabelFormat: null,
+  barSize: undefined
 };
 
 export default SimpleBarChart;

--- a/src/components/charts/chart/chart.js
+++ b/src/components/charts/chart/chart.js
@@ -169,7 +169,9 @@ Chart.propTypes = {
   /** Custom tooltip to pass down to chart */
   customTooltip: PropTypes.node,
   /** Function transforming y axis value */
-  getCustomYLabelFormat: PropTypes.func
+  getCustomYLabelFormat: PropTypes.func,
+  /** Specific for bar chart - single bar size */
+  barSize: PropTypes.number
 };
 
 Chart.defaultProps = {
@@ -191,7 +193,8 @@ Chart.defaultProps = {
   customXAxisTick: null,
   customYAxisTick: null,
   customTooltip: null,
-  getCustomYLabelFormat: null
+  getCustomYLabelFormat: null,
+  barSize: undefined
 };
 
 export default Chart;

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -184,6 +184,7 @@ const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
     height={500}
     loading={state.loading}
     getCustomYLabelFormat={getCustomYLabelFormat}
+    barSize={40}
     showUnit
   />
 </React.Fragment>


### PR DESCRIPTION
Add a `barSize` prop to bar chart to allow passing width of a single bar. Update example:

![image](https://user-images.githubusercontent.com/6136899/48909476-49ad4580-ee65-11e8-91d4-1c0e1a3daa4f.png)
