### PR TITLE
Tweaks format of y axis units in line chart / composed chart

### DIFF
--- a/src/components/charts/chart-composed/chart-composed.js
+++ b/src/components/charts/chart-composed/chart-composed.js
@@ -100,7 +100,6 @@ class ChartComposed extends PureComponent {
                   (
                     <CustomYAxisTick
                       precision={config.precision}
-                      unit={unit}
                       suffix={suffix}
                       getCustomYLabelFormat={getCustomYLabelFormat}
                     />

--- a/src/components/charts/chart-composed/chart-composed.md
+++ b/src/components/charts/chart-composed/chart-composed.md
@@ -99,8 +99,6 @@ const lineWithDots = config.columns && config.columns.lineWithDots.map(column =>
                   );
                 });
 
-const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
-
 <ChartComposed
     config={state.config}
     data={state.data}
@@ -110,7 +108,6 @@ const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
     height={500}
     loading={state.loading}
     onLegendChange={handleLegendChange}
-    getCustomYLabelFormat={getCustomYLabelFormat}
     showUnit
 >
   {lineChart}

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -54,7 +54,6 @@ const toggleChartType = (filtersSelected) => {
 Example with linear type of line chart
 ```js
 const data = require('../assets/data.js');
-const format = require('d3-format').format;
 initialState = {
   ...data,
   type: 'line',
@@ -83,7 +82,6 @@ const toggleChartType = (filtersSelected) => {
     return { type };
   });
 }
-const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
 <React.Fragment>
   <Button onClick={toggleChartType} >
     Toggle type
@@ -99,7 +97,6 @@ const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
     loading={state.loading}
     onLegendChange={handleLegendChange}
     lineType='linear'
-    getCustomYLabelFormat={getCustomYLabelFormat}
     showUnit
   />
 </React.Fragment>
@@ -110,7 +107,6 @@ Example with projected data
 ```js
 const data = require('../assets/data.js');
 const projectedData = require('../assets/projected-data.js');
-const format = require('d3-format').format;
 initialState = {
   ...data,
   config: { ...data.config, ...projectedData.config },
@@ -141,7 +137,6 @@ const toggleChartType = (filtersSelected) => {
     return { type };
   });
 }
-const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
 <React.Fragment>
   <Button onClick={toggleChartType} >
     Toggle type
@@ -158,7 +153,6 @@ const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
     loading={state.loading}
     onLegendChange={handleLegendChange}
     lineType='linear'
-    getCustomYLabelFormat={getCustomYLabelFormat}
     showUnit
   />
 </React.Fragment>

--- a/src/components/charts/line/axis-ticks.js
+++ b/src/components/charts/line/axis-ticks.js
@@ -18,20 +18,19 @@ export const CustomXAxisTick = ({ x, y, payload }) => (
   </g>
 );
 
-const getYLabelformat = (unit, precision, value) => {
-  let typeValue = unit ? 'r' : 's';
-  if (precision) typeValue = 'f';
+const getYLabelformat = (precision, value) => {
+  const typeValue = precision ? 'f' : 's';
   return `${format(`.${2}${typeValue}`)(value)}`;
 };
 
 export const CustomYAxisTick = (
-  { index, x, y, payload, unit, precision, getCustomYLabelFormat, suffix }
+  { index, x, y, payload, precision, getCustomYLabelFormat, suffix }
 ) =>
   {
-    const yLabelFormat = (_unit, _precision, value) =>
+    const yLabelFormat = (_precision, value) =>
       getCustomYLabelFormat
         ? getCustomYLabelFormat(value)
-        : getYLabelformat(_unit, _precision, value);
+        : getYLabelformat(_precision, value);
     return (
       <g transform={`translate(${x},${y})`}>
         <text
@@ -48,7 +47,7 @@ export const CustomYAxisTick = (
               (payload.value === 0 ||
                 payload.value < 0 && payload.value > -0.001)
               ? '0'
-              : `${yLabelFormat(unit, precision, payload.value)}${suffix || ''}`
+              : `${yLabelFormat(precision, payload.value)}${suffix || ''}`
           }
         </text>
       </g>
@@ -68,7 +67,6 @@ CustomYAxisTick.propTypes = {
   y: PropTypes.number,
   index: PropTypes.number,
   payload: PropTypes.object,
-  unit: PropTypes.oneOfType([ PropTypes.string, PropTypes.bool ]),
   suffix: PropTypes.string,
   precision: PropTypes.number,
   getCustomYLabelFormat: PropTypes.func
@@ -79,10 +77,9 @@ CustomYAxisTick.defaultProps = {
   y: null,
   index: null,
   payload: {},
-  unit: null,
   suffix: null,
   precision: null,
   getCustomYLabelFormat: null
 };
 
-CustomYAxisTick.defaultProps = { precision: null, unit: false };
+CustomYAxisTick.defaultProps = { precision: null };

--- a/src/components/charts/line/line.js
+++ b/src/components/charts/line/line.js
@@ -115,7 +115,6 @@ class ChartLine extends PureComponent {
                 (
                   <CustomYAxisTick
                     precision={config.precision}
-                    unit={unit}
                     suffix={suffix}
                     getCustomYLabelFormat={getCustomYLabelFormat}
                   />


### PR DESCRIPTION
- Remove passing `unit` prop to the `CustomYAxisTick` component in chart-composed and chart-line.
- Remove custom formats from .md files - they aren't necessary anymore.

These changes are connected with this [bug](https://github.com/ClimateWatch-Vizzuality/climate-watch-components/pull/76#issuecomment-440336233), here "[fixed](https://github.com/ClimateWatch-Vizzuality/climate-watch-components/pull/76#issuecomment-440371523)" by me before. I noticed that adding a custom format to .md files was in fact workaround, not fix.
The only job of `unit` prop in `CustomYAxisTick` is to set **'r'** format (without SI prefix) when `unit` prop is provided. For me, it doesn't make sense right now, because we are going to provide `unit` for line/composed chart to display y-axis unit label and use mainly **'s'** format for y-axis ticks (with SI prefix) in SA and CWC. So I think we can use **'s'** format as default, remove passing `unit` prop to `CustomYAxisTick`  and then, if it's needed, overwrite it by passing custom format in `getCustomYLabelFormat` what we already do in few places.

I hope the description above is clear because even I'm a little bit confused :/