### PR TITLE
Display unit on x-axis and change layout of a tooltip in bar-chart

### DIFF
--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -11,6 +11,9 @@ import {
 } from 'recharts';
 import debounce from 'lodash/debounce';
 import yAxisLabel from 'components/charts/y-axis-label';
+import cx from 'classnames';
+import styles from 'components/charts/y-axis-label/y-axis-label-styles.scss';
+import has from 'lodash/has';
 import { CustomXAxisTick, CustomYAxisTick } from './axis-ticks';
 import BarTooltipChart from './bar-tooltip-chart';
 
@@ -45,15 +48,24 @@ class SimpleBarChart extends PureComponent {
       getCustomYLabelFormat,
       barSize
     } = this.props;
-    const unit = showUnit &&
-      config &&
-      config.axes &&
-      config.axes.yLeft &&
-      config.axes.yLeft.unit
+
+    const yUnit = showUnit && has(config, 'axes.yLeft.unit')
       ? config.axes.yLeft.unit
       : null;
-    const LineChartMargin = { top: 10, right: 0, left: -10, bottom: 0 };
 
+    const xUnit = showUnit && has(config, 'axes.xBottom.unit')
+      ? config.axes.xBottom.unit
+      : null;
+
+    const xLabel = has(config, 'axes.xBottom.label')
+      ? config.axes.xBottom.label
+      : null;
+
+    const yLabel = has(config, 'axes.yLeft.label')
+      ? config.axes.yLeft.label
+      : null;
+
+    const LineChartMargin = { top: 10, right: 0, left: -10, bottom: 0 };
     const dataKeys = Object.keys(config.columns).filter(col => col !== 'x');
 
     return (
@@ -73,6 +85,13 @@ class SimpleBarChart extends PureComponent {
               tickSize={8}
               domain={domain && domain.x || [ 'auto', 'auto' ]}
               interval="preserveStartEnd"
+              label={{
+                value: xUnit,
+                dx: xLabel.dx,
+                dy: xLabel.dy,
+                className: cx(styles.yAxisLabel, xLabel.className),
+                position: 'insideBottomRight'
+              }}
             />
             <YAxis
               axisLine={false}
@@ -90,7 +109,7 @@ class SimpleBarChart extends PureComponent {
               domain={domain && domain.y || [ 'auto', 'auto' ]}
               interval="preserveStartEnd"
             >
-              {yAxisLabel(unit)}
+              {yAxisLabel(yUnit, yLabel.dx, yLabel.dy, yLabel.className)}
             </YAxis>
             <CartesianGrid vertical={false} />
             <Tooltip

--- a/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-component.jsx
+++ b/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-component.jsx
@@ -1,8 +1,6 @@
 import React, { PureComponent } from 'react';
 import Proptypes from 'prop-types';
 import { format } from 'd3-format';
-import cx from 'classnames';
-
 import styles from './bar-tooltip-chart-styles.scss';
 
 class BarTooltipChart extends PureComponent {
@@ -25,21 +23,28 @@ class BarTooltipChart extends PureComponent {
 
   render() {
     const { config, content } = this.props;
-    const unit = config &&
+    const yUnit = config &&
       config.axes &&
       config.axes.yLeft &&
       config.axes.yLeft.unit;
+    const xUnit = config &&
+      config.axes &&
+      config.axes.xBottom &&
+      config.axes.xBottom.unit;
+
     return (
       <div className={styles.tooltip}>
         <div className={styles.tooltipHeader}>
-          <span className={cx(styles.labelName)}>
+          {xUnit && (
+            <span
+              className={styles.unit}
+              /* eslint-disable-line*/
+              dangerouslySetInnerHTML={{ __html: xUnit }}
+            />
+          )}
+          <span>
             {content.label}
           </span>
-          <span
-            className={styles.unit}
-            /* eslint-disable-line*/
-            dangerouslySetInnerHTML={{ __html: unit }}
-          />
         </div>
         {
           content &&
@@ -52,16 +57,23 @@ class BarTooltipChart extends PureComponent {
                   config.tooltip[y.dataKey] && 
                   config.tooltip[y.dataKey].label
                   ? (
-                    <div key={`${y.dataKey}`} className={styles.label}>
-                      <p className={styles.labelValue}>
+                    <div key={`${y.dataKey}`} className={styles.tooltipHeader}>
+                      {yUnit && (
+                        <span
+                          className={styles.unit}
+                          /* eslint-disable-line*/
+                          dangerouslySetInnerHTML={{ __html: yUnit }}
+                        />
+                      )}
+                      <span>
                         {this.renderValue(y)}
-                      </p>
+                      </span>
                     </div>
 )
                   : null
             )
         }
-        {content && !content.payload && <div>No data fool</div>}
+        {content && !content.payload && <div>No data available</div>}
       </div>
     );
   }

--- a/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-styles.scss
+++ b/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-styles.scss
@@ -15,27 +15,16 @@
   align-items: center;
   padding-bottom: 10px;
   font-size: $font-size-s;
+
+  &:first-child{
+    color: $theme-color;
+  }
+
+  &:last-child{
+    color: #77818c;
+  }
 }
 
 .unit {
-  font-size: $font-size-s;
-}
-
-.label {
-  display: flex;
-  flex-direction: row;
-  padding-left: 10px;
-  font-size: $font-size-s;
-  color: #77818c;
-}
-
-.labelName {
-  color: $theme-color;
-  padding-left: 10px;
-}
-
-.labelValue {
-  text-align: right;
-  min-width: 45px;
-  margin: 0;
+  margin-right: 10px;
 }

--- a/src/components/charts/bar-chart/data.js
+++ b/src/components/charts/bar-chart/data.js
@@ -11,8 +11,18 @@ export const domain = { x: [ 'auto', 'auto' ], y: [ 0, 'auto' ] };
 
 export const config = {
   axes: {
-    xBottom: { name: 'Age distribution', unit: '', format: 'string' },
-    yLeft: { name: 'Number of people', unit: '', format: 'number' }
+    xBottom: {
+      name: 'Age distribution',
+      unit: 'age',
+      format: 'string',
+      label: { dx: 0, dy: 0, className: '' }
+    },
+    yLeft: {
+      name: 'Number of people',
+      unit: 'people',
+      format: 'number',
+      label: { dx: 2, dy: 14, className: '' }
+    }
   },
   tooltip: { y: { label: 'people' } },
   animation: false,

--- a/src/components/charts/y-axis-label/y-axis-label.js
+++ b/src/components/charts/y-axis-label/y-axis-label.js
@@ -19,10 +19,10 @@ const htmlToSvgSubscript = unitY => {
   });
 };
 
-const yAxisLabel = (unit, className, x = '8', y = '20') => (
+const yAxisLabel = (unit, dx = '8', dy = '20', className) => (
   <Label
     content={() => (
-      <text x={x} y={y} className={cx(styles.yAxisLabel, className)}>
+      <text dx={dx} dy={dy} className={cx(styles.yAxisLabel, className)}>
         {unit && htmlToSvgSubscript(unit)}
       </text>
     )}


### PR DESCRIPTION
- Enable displaying x-axis unit on bar chart if needed,
- Show in bar-chart tooltip x- and y-axis units if they are present,
- Change absolute coordinates x, y to relative coordinates dx, dy in y-axis-label,
![screenshot from 2018-11-26 14-03-14](https://user-images.githubusercontent.com/15097138/49018769-2dbae400-f184-11e8-8618-f0f38805fa0b.png)
