### PR TITLE
Fix for empty 'label' prop in bar-chart

### DIFF
--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -59,11 +59,11 @@ class SimpleBarChart extends PureComponent {
 
     const xLabel = has(config, 'axes.xBottom.label')
       ? config.axes.xBottom.label
-      : null;
+      : undefined;
 
     const yLabel = has(config, 'axes.yLeft.label')
       ? config.axes.yLeft.label
-      : null;
+      : undefined;
 
     const LineChartMargin = { top: 10, right: 0, left: -10, bottom: 0 };
     const dataKeys = Object.keys(config.columns).filter(col => col !== 'x');
@@ -87,9 +87,9 @@ class SimpleBarChart extends PureComponent {
               interval="preserveStartEnd"
               label={{
                 value: xUnit,
-                dx: xLabel.dx,
-                dy: xLabel.dy,
-                className: cx(styles.yAxisLabel, xLabel.className),
+                dx: xLabel && xLabel.dx,
+                dy: xLabel && xLabel.dy,
+                className: cx(styles.yAxisLabel, xLabel && xLabel.className),
                 position: 'insideBottomRight'
               }}
             />
@@ -109,7 +109,7 @@ class SimpleBarChart extends PureComponent {
               domain={domain && domain.y || [ 'auto', 'auto' ]}
               interval="preserveStartEnd"
             >
-              {yAxisLabel(yUnit, yLabel.dx, yLabel.dy, yLabel.className)}
+              {yAxisLabel(yUnit, yLabel)}
             </YAxis>
             <CartesianGrid vertical={false} />
             <Tooltip

--- a/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-component.jsx
+++ b/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-component.jsx
@@ -69,7 +69,7 @@ class BarTooltipChart extends PureComponent {
                         {this.renderValue(y)}
                       </span>
                     </div>
-)
+                  )
                   : null
             )
         }

--- a/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-styles.scss
+++ b/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-styles.scss
@@ -16,11 +16,11 @@
   padding-bottom: 10px;
   font-size: $font-size-s;
 
-  &:first-child{
+  &:first-child {
     color: $theme-color;
   }
 
-  &:last-child{
+  &:last-child {
     color: #77818c;
   }
 }

--- a/src/components/charts/y-axis-label/y-axis-label.js
+++ b/src/components/charts/y-axis-label/y-axis-label.js
@@ -19,14 +19,17 @@ const htmlToSvgSubscript = unitY => {
   });
 };
 
-const yAxisLabel = (unit, dx = '8', dy = '20', className) => (
-  <Label
-    content={() => (
-      <text dx={dx} dy={dy} className={cx(styles.yAxisLabel, className)}>
-        {unit && htmlToSvgSubscript(unit)}
-      </text>
-    )}
-  />
-);
+const yAxisLabel = (unit, labelConfig = { dx: '8', dy: '20' }) => {
+  const { dx, dy, className } = labelConfig;
+  return (
+    <Label
+      content={() => (
+        <text dx={dx} dy={dy} className={cx(styles.yAxisLabel, className)}>
+          {unit && htmlToSvgSubscript(unit)}
+        </text>
+      )}
+    />
+  );
+};
 
 export default yAxisLabel;


### PR DESCRIPTION
- Fix error in bar-chart when `label` prop in `config.axes.xBottom` or `config.axes.yLeft` wasn't provided.