### PR TITLE
Don't show sorting arrows on columns without header

### DIFF
--- a/src/components/table/components/header-row-renderer-component.jsx
+++ b/src/components/table/components/header-row-renderer-component.jsx
@@ -5,11 +5,12 @@ import idleSort from '../assets/collapse.svg';
 import styles from '../table-styles.scss';
 
 const headerRowRenderer = props => {
-  const { className, columns, style } = props;
+  const { className, columns, style, hiddenColumnHeaderLabels } = props;
   return (
     <div className={className} role="row" style={style}>
       {columns.map(c => {
-        if (!c.props['aria-sort']) {
+        const columnName = c.props['aria-label'];
+        if (!hiddenColumnHeaderLabels.includes(columnName) && !c.props['aria-sort']) {
           c.props.children.push(
             <Icon icon={idleSort} theme={{ icon: styles.idleSortIcon }} />
           );
@@ -23,12 +24,14 @@ const headerRowRenderer = props => {
 headerRowRenderer.propTypes = {
   className: PropTypes.oneOfType(PropTypes.object, PropTypes.string),
   columns: PropTypes.arrayOf(PropTypes.node).isRequired,
-  style: PropTypes.string
-};
+  style: PropTypes.string,
+  hiddenColumnHeaderLabels: PropTypes.arrayOf(PropTypes.string)
+}
 
 headerRowRenderer.defaultProps = {
   className: null,
-  style: null
+  style: null,
+  hiddenColumnHeaderLabels: []
 }
 
 

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -12,7 +12,6 @@ import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import cx from 'classnames';
 import difference from 'lodash/difference';
 
-import { pixelBreakpoints } from '../../styles/responsive';
 import MultiSelect from '../multiselect';
 import cellRenderer from './components/cell-renderer-component';
 import styles from './table-styles.scss';
@@ -63,27 +62,13 @@ class Table extends PureComponent {
     );
   };
 
-  getResponsiveWidth = (columns, width) => {
-    if (columns.length === 1) return width;
-
-    const isMinColumSized = width / columns < this.standardColumnWidth;
-
-    let responsiveRatio = 1.4;
-    // Mobile
-    let responsiveColumnRatio = 0.2;
-    if (
-      width > pixelBreakpoints.portrait && width < pixelBreakpoints.landscape
-    ) {
-      responsiveColumnRatio = 0.1;
-      responsiveRatio = 1.2; // Tablet
-    } else if (width > pixelBreakpoints.landscape) {
-      // Desktop
-      responsiveColumnRatio = 0.1;
-      responsiveRatio = 1;
-    }
-    const columnRatio = isMinColumSized ? responsiveColumnRatio : 0;
-    const columnExtraWidth = columnRatio * columns;
-    return width * responsiveRatio * (1 + columnExtraWidth);
+  getResponsiveWidth = (data, columns, width) => {
+    const columnsLenght = columns.length;
+    if (columnsLenght === 1) return width;
+    return columns.reduce(
+      (acc, column) => acc + this.getColumnLength(data, column.label),
+      0
+    );
   };
 
   getDataSorted = (data, sortBy, sortDirection) => {
@@ -232,7 +217,6 @@ class Table extends PureComponent {
           considerableMargin ||
         120;
     };
-
     return (
       <div className={cx({ [styles.hasColumnSelect]: hasColumnSelect })}>
         {
@@ -268,7 +252,7 @@ class Table extends PureComponent {
             {({ width }) => (
               <VirtualizedTable
                 className={styles.table}
-                width={this.getResponsiveWidth(activeColumns.length, width)}
+                width={this.getResponsiveWidth(data, activeColumns, width)}
                 height={tableHeight}
                 headerHeight={headerHeight}
                 rowClassName={this.rowClassName}

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -62,7 +62,7 @@ class Table extends PureComponent {
     );
   };
 
-  getResponsiveWidth = (data, columns, width) => {
+  getFullWidth = (data, columns, width) => {
     const columnsLenght = columns.length;
     if (columnsLenght === 1) return width;
     const totalWidth = columns.reduce(
@@ -253,7 +253,7 @@ class Table extends PureComponent {
             {({ width }) => (
               <VirtualizedTable
                 className={styles.table}
-                width={this.getResponsiveWidth(data, activeColumns, width)}
+                width={this.getFullWidth(data, activeColumns, width)}
                 height={tableHeight}
                 headerHeight={headerHeight}
                 rowClassName={this.rowClassName}

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -65,10 +65,11 @@ class Table extends PureComponent {
   getResponsiveWidth = (data, columns, width) => {
     const columnsLenght = columns.length;
     if (columnsLenght === 1) return width;
-    return columns.reduce(
+    const totalWidth = columns.reduce(
       (acc, column) => acc + this.getColumnLength(data, column.label),
       0
     );
+    return totalWidth < width ? width : totalWidth;
   };
 
   getDataSorted = (data, sortBy, sortDirection) => {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -281,7 +281,13 @@ class Table extends PureComponent {
                 sortBy={sortBy}
                 sortDirection={sortDirection}
                 rowGetter={({ index }) => data[index]}
-                headerRowRenderer={headerRowRenderer}
+                headerRowRenderer={({ columns, style, className }) =>
+                  headerRowRenderer({
+                    ...this.props,
+                    columns,
+                    style,
+                    className
+                  })}
               >
                 {this
                   .getColumnData()


### PR DESCRIPTION
- Don't show sorting arrows on columns without header: To try add the link column to the table:
- Fix the total width of the chart calculation based in the columns width

![image](https://user-images.githubusercontent.com/9701591/49083349-9c637480-f24c-11e8-8231-a340e85abdf2.png)
