### PR TITLE
Fix/table component header tweaks

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,7 +7,7 @@
     "no-duplicate-selectors": null,
     "length-zero-no-unit": null,
     "selector-pseudo-class-no-unknown": [
-      true, { ignorePseudoClasses: ["global"] }
+      true, { ignorePseudoClasses: ["global", "export"] }
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "react": "16.4.1",
     "react-dom": "16.4.1",
     "react-styleguidist": "7.1.0",
+    "react-truncate": "2.4.0",
     "release": "github:vizzuality/release#4.0.0",
     "resolve-url-loader": "2.3.0",
     "sass-loader": "7.0.3",

--- a/src/components/charts/bubble-chart/bubble-chart-styles.scss
+++ b/src/components/charts/bubble-chart/bubble-chart-styles.scss
@@ -1,33 +1,6 @@
 @import '~styles/settings.scss';
+@import '~styles/react-tooltip-white.scss';
 
 .circle {
   cursor: pointer;
-}
-
-:global {
-  .bubbleChartTooltip {
-    font-family: $font-family-1;
-    padding: 15px;
-    font-size: $font-size-xs;
-    letter-spacing: -0.1px;
-    box-shadow: 0 5px 15px 0 rgba(17, 55, 80, 0.15);
-    max-width: 300px;
-
-    &.__react_component_tooltip.type-dark {
-      color: $theme-color;
-      background-color: $white;
-    }
-
-    &.__react_component_tooltip.show {
-      opacity: 1;
-    }
-
-    & .multi-line {
-      text-align: left;
-    }
-
-    &::after { // Hides the arrow
-      display: none;
-    }
-  }
 }

--- a/src/components/charts/bubble-chart/bubble-chart.js
+++ b/src/components/charts/bubble-chart/bubble-chart.js
@@ -74,7 +74,7 @@ class BubbleChart extends PureComponent {
         <ReactTooltip
           place="left"
           id="chartTooltip"
-          className={cx('bubbleChartTooltip', tooltipClassName)}
+          className={cx('reactTooltipWhite', tooltipClassName)}
           multiline
         />
       </Fragment>

--- a/src/components/table/components/header-row-renderer-component.jsx
+++ b/src/components/table/components/header-row-renderer-component.jsx
@@ -12,7 +12,9 @@ const headerRowRenderer = props => {
         const columnName = c.props['aria-label'];
         if (!hiddenColumnHeaderLabels.includes(columnName) && !c.props['aria-sort']) {
           c.props.children.push(
-            <Icon icon={idleSort} theme={{ icon: styles.idleSortIcon }} />
+            <span>
+              <Icon icon={idleSort} theme={{ icon: styles.idleSortIcon }} />
+            </span>
           );
         }
         return c;

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -2,6 +2,8 @@
 
 $sort-icon-width: 24px;
 
+:export { sorticonwidth: $sort-icon-width; }
+
 .tableWrapper {
   position: relative;
   overflow-x: hidden;
@@ -49,7 +51,6 @@ $sort-icon-width: 24px;
   .ReactVirtualized__Table__headerTruncatedText {
     display: inline-block;
     max-width: 100%;
-    // white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
     user-select: none;
@@ -207,5 +208,3 @@ $sort-icon-width: 24px;
   width: $sort-icon-width;
   height: 8px;
 }
-
-:export { sortIconWidth: $sort-icon-width; }

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -1,5 +1,7 @@
 @import '~styles/settings';
 
+$sort-icon-width: 24px;
+
 .tableWrapper {
   position: relative;
   overflow-x: hidden;
@@ -74,7 +76,7 @@
   }
 
   .ReactVirtualized__Table__sortableHeaderIcon {
-    flex: 0 0 24px;
+    flex: 0 0 $sort-icon-width;
     height: 1em;
     width: 1em;
     fill: currentColor;
@@ -160,10 +162,6 @@
   }
 }
 
-.columHeaderText {
-  max-height: 2.2rem;
-}
-
 .columnSelector :global {
   position: absolute;
   right: 0;
@@ -206,6 +204,8 @@
 }
 
 .idleSortIcon {
-  width: 24px;
+  width: $sort-icon-width;
   height: 8px;
 }
+
+:export { sortIconWidth: $sort-icon-width; }

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -47,7 +47,7 @@
   .ReactVirtualized__Table__headerTruncatedText {
     display: inline-block;
     max-width: 100%;
-    white-space: nowrap;
+    // white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
     user-select: none;
@@ -114,6 +114,9 @@
 
   .ReactVirtualized__Table__sortableHeaderColumn {
     cursor: pointer;
+    display: inline-flex;
+    align-items: flex-end;
+    margin-bottom: 10px;
 
     &:focus {
       outline: none;
@@ -157,12 +160,15 @@
   }
 }
 
+.columHeaderText {
+  max-height: 2.2rem;
+}
+
 .columnSelector :global {
   position: absolute;
   right: 0;
   top: -17px;
   z-index: 10;
-  border-bottom: solid 1px $theme-color-light;
   width: 25px;
   background-color: white;
 
@@ -200,8 +206,6 @@
 }
 
 .idleSortIcon {
-  width: 8px;
+  width: 24px;
   height: 8px;
-  margin-left: 3px;
-  transform: translateY(-50%);
 }

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -50,6 +50,7 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+    user-select: none;
   }
 
   .ReactVirtualized__Table__headerColumn,

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import _sortBy from 'lodash/sortBy';
 import reverse from 'lodash/reverse';
-import capitalize from 'lodash/capitalize';
 import {
   Table as VirtualizedTable,
   Column,
@@ -175,6 +174,9 @@ class Table extends PureComponent {
       .concat(difference(activeColumnNames, firstColumnHeaders));
   };
 
+  capitalizeFirstLetter = text =>
+    `${text.charAt(0).toUpperCase()}${text.slice(1)}`;
+
   render() {
     const {
       data,
@@ -199,7 +201,8 @@ class Table extends PureComponent {
     const hasColumnSelectedOptions = hasColumnSelect && columnsOptions;
     const columnLabel = columnSlug => {
       if (hiddenColumnHeaderLabels.includes(columnSlug)) return '';
-      return capitalize(columnSlug.replace(/_/g, ' '));
+      const result = columnSlug.replace(/_/g, ' ');
+      return this.capitalizeFirstLetter(result);
     };
 
     const rowsHeight = d => {

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -10,7 +10,7 @@ import {
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import cx from 'classnames';
 import difference from 'lodash/difference';
-
+import ReactTooltip from 'react-tooltip';
 import MultiSelect from '../multiselect';
 import cellRenderer from './components/cell-renderer-component';
 import styles from './table-styles.scss';
@@ -201,8 +201,8 @@ class Table extends PureComponent {
     const hasColumnSelectedOptions = hasColumnSelect && columnsOptions;
     const columnLabel = columnSlug => {
       if (hiddenColumnHeaderLabels.includes(columnSlug)) return '';
-      const result = columnSlug.replace(/_/g, ' ');
-      return this.capitalizeFirstLetter(result);
+      const headerLabel = columnSlug.replace(/_/g, ' ');
+      return this.capitalizeFirstLetter(headerLabel);
     };
 
     const rowsHeight = d => {
@@ -221,6 +221,18 @@ class Table extends PureComponent {
           considerableMargin ||
         120;
     };
+    const getHeaderLabel = columnText => (
+      <div
+        data-for="header-label"
+        data-tip={columnLabel(columnText)}
+        data-offset="{'top': 40, 'left': 0}"
+        className={styles.columHeaderText}
+        title=""
+      >
+        {columnLabel(columnText)}
+      </div>
+    );
+
     return (
       <div className={cx({ [styles.hasColumnSelect]: hasColumnSelect })}>
         {
@@ -287,7 +299,7 @@ class Table extends PureComponent {
                         [styles.allTextVisible]: dynamicRowsHeight
                       })}
                       key={column}
-                      label={columnLabel(column)}
+                      label={getHeaderLabel(column)}
                       dataKey={column}
                       flexGrow={0}
                       cellRenderer={cell =>
@@ -298,6 +310,12 @@ class Table extends PureComponent {
               </VirtualizedTable>
             )}
           </AutoSizer>
+          <ReactTooltip
+            place="left"
+            id="header-label"
+            className="bubbleChartTooltip"
+            multiline
+          />
         </div>
       </div>
     );

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -225,7 +225,7 @@ class Table extends PureComponent {
 
     const getHeaderLabel = (columnText, columnData) => {
       const { width } = this.columnWidthProps(columnText, columnData);
-      const sortIconWidth = styles.sortIconWidth.replace('px', '');
+      const sortIconWidth = styles.sorticonwidth.replace('px', '');
       const truncateWidth = width - sortIconWidth;
       return (
         <Truncate
@@ -385,7 +385,7 @@ Table.propTypes = {
 Table.defaultProps = {
   sortBy: 'value',
   tableHeight: 460,
-  headerHeight: 30,
+  headerHeight: 42,
   defaultColumns: [],
   hasColumnSelect: false,
   setColumnWidth: null,

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -11,6 +11,7 @@ import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import cx from 'classnames';
 import difference from 'lodash/difference';
 import ReactTooltip from 'react-tooltip';
+import Truncate from 'react-truncate';
 import MultiSelect from '../multiselect';
 import cellRenderer from './components/cell-renderer-component';
 import styles from './table-styles.scss';
@@ -221,17 +222,25 @@ class Table extends PureComponent {
           considerableMargin ||
         120;
     };
-    const getHeaderLabel = columnText => (
-      <div
-        data-for="header-label"
-        data-tip={columnLabel(columnText)}
-        data-offset="{'top': 40, 'left': 0}"
-        className={styles.columHeaderText}
-        title=""
-      >
-        {columnLabel(columnText)}
-      </div>
-    );
+
+    const getHeaderLabel = (columnText, columnData) => {
+      const { width } = this.columnWidthProps(columnText, columnData);
+      const sortIconWidth = styles.sortIconWidth.replace('px', '');
+      const truncateWidth = width - sortIconWidth;
+      return (
+        <Truncate
+          data-for="header-label"
+          data-tip={columnLabel(columnText)}
+          data-offset="{'top': 40, 'left': 0}"
+          title=""
+          lines={2}
+          ellipsis={<span>...</span>}
+          width={truncateWidth}
+        >
+          {columnLabel(columnText)}
+        </Truncate>
+      );
+    };
 
     return (
       <div className={cx({ [styles.hasColumnSelect]: hasColumnSelect })}>
@@ -299,7 +308,7 @@ class Table extends PureComponent {
                         [styles.allTextVisible]: dynamicRowsHeight
                       })}
                       key={column}
-                      label={getHeaderLabel(column)}
+                      label={getHeaderLabel(column, data)}
                       dataKey={column}
                       flexGrow={0}
                       cellRenderer={cell =>
@@ -313,7 +322,7 @@ class Table extends PureComponent {
           <ReactTooltip
             place="left"
             id="header-label"
-            className="bubbleChartTooltip"
+            className="reactTooltipWhite"
             multiline
           />
         </div>

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -1,13 +1,14 @@
 ```jsx
 const data = require('./data.json');
 
-const defaultColumns = ["name", "here it is really really really really really long label definition_UPPERCASE_lowercase and something funny at the end of that", "unit", "composite_name"];
+const defaultColumns = ["name", "description_description_description_description_description_description_description_description_description_description_description_description_description", "unit", "composite_name"];
 const ellipsisColumns = ["composite_name"];
 
 <Table
   data={data}
   headerHeight={42}
   hasColumnSelect
+  // setColumnWidth={() => 150}
   defaultColumns={defaultColumns}
   ellipsisColumns={ellipsisColumns}
   emptyValueLabel={'Not specified'}

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -1,11 +1,12 @@
 ```jsx
 const data = require('./data.json');
 
-const defaultColumns = ["name", "definition_UPCASE_lowcase", "unit", "composite_name"];
+const defaultColumns = ["name", "here it is really really really really really long label definition_UPPERCASE_lowercase and something funny at the end of that", "unit", "composite_name"];
 const ellipsisColumns = ["composite_name"];
 
 <Table
   data={data}
+  headerHeight={42}
   hasColumnSelect
   defaultColumns={defaultColumns}
   ellipsisColumns={ellipsisColumns}

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -1,14 +1,12 @@
 ```jsx
 const data = require('./data.json');
 
-const defaultColumns = ["name", "description_description_description_description_description_description_description_description_description_description_description_description_description", "unit", "composite_name"];
+const defaultColumns = ["name", "definition", "very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_header_label", "unit", "composite_name"];
 const ellipsisColumns = ["composite_name"];
 
 <Table
   data={data}
-  headerHeight={42}
   hasColumnSelect
-  // setColumnWidth={() => 150}
   defaultColumns={defaultColumns}
   ellipsisColumns={ellipsisColumns}
   emptyValueLabel={'Not specified'}

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -1,7 +1,7 @@
 ```jsx
 const data = require('./data.json');
 
-const defaultColumns = ["name", "definition", "unit", "composite_name"];
+const defaultColumns = ["name", "definition_UPCASE_lowcase", "unit", "composite_name"];
 const ellipsisColumns = ["composite_name"];
 
 <Table

--- a/src/styles/react-tooltip-white.scss
+++ b/src/styles/react-tooltip-white.scss
@@ -1,0 +1,29 @@
+@import '~styles/settings.scss';
+
+:global {
+  .reactTooltipWhite {
+    font-family: $font-family-1;
+    padding: 15px;
+    font-size: $font-size-xs;
+    letter-spacing: -0.1px;
+    box-shadow: 0 5px 15px 0 rgba(17, 55, 80, 0.15);
+    max-width: 300px;
+
+    &.__react_component_tooltip.type-dark {
+      color: $theme-color;
+      background-color: $white;
+    }
+
+    &.__react_component_tooltip.show {
+      opacity: 1;
+    }
+
+    & .multi-line {
+      text-align: left;
+    }
+
+    &::after { // Hides the arrow
+      display: none;
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7452,6 +7452,14 @@ react-selectize@3.0.1:
     prelude-ls "^1.1.1"
     tether "^1.1.1"
 
+react-simple-maps@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/react-simple-maps/-/react-simple-maps-0.12.1.tgz#afc732362bb8eb2e5609a61d33bf6567d0fdd02a"
+  dependencies:
+    d3-geo "1.6.3"
+    d3-geo-projection "1.2.2"
+    topojson-client "2.1.0"
+
 react-slick@^0.23.2:
   version "0.23.2"
   resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.23.2.tgz#8d8bdbc77a6678e8ad36f50c32578c7c0f1c54f6"
@@ -7462,13 +7470,6 @@ react-slick@^0.23.2:
     lodash.debounce "^4.0.8"
     prettier "^1.14.3"
     resize-observer-polyfill "^1.5.0"
-react-simple-maps@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/react-simple-maps/-/react-simple-maps-0.12.1.tgz#afc732362bb8eb2e5609a61d33bf6567d0fdd02a"
-  dependencies:
-    d3-geo "1.6.3"
-    d3-geo-projection "1.2.2"
-    topojson-client "2.1.0"
 
 react-smooth@1.0.0:
   version "1.0.0"
@@ -7576,6 +7577,11 @@ react-transition-group@^2.2.1:
     loose-envify "^1.3.1"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-truncate@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-truncate/-/react-truncate-2.4.0.tgz#3cf5ff09ab86f93e3c078d359f4de6d75aa60510"
+  integrity sha512-3QW11/COYwi6iPUaunUhl06DW5NJBJD1WkmxW5YxqqUu6kvP+msB3jfoLg8WRbu57JqgebjVW8Lknw6T5/QZdA==
 
 react-virtualized@9.20.1:
   version "9.20.1"


### PR DESCRIPTION
In reference to this [task](https://www.pivotaltracker.com/story/show/162209923), I made some changes in table component. Before start run `yarn install` to install new package `react-truncate` (more below).
![screenshot from 2018-11-29 11-48-26](https://user-images.githubusercontent.com/15097138/49222581-1b36e980-f3d4-11e8-8569-8c7566e8784d.png)


- Fix capitalization of header label text in table component: now header capitalizes only first letter of the first word of header text, doesn't modify case of other letters:
ex: `cumulative GHG emission` to `Cumulative GHG emission`
- Add white react tooltip after hover on header text:
- Use new package [react-truncate](https://www.npmjs.com/package/react-truncate) to truncate header text into maximum two lines and show '...' at the end, if the text is longer. It's hard to do it for all browsers without an external library, so I choosed this one, let me know if it's ok
- Extract global class `reactTooltipWhite` to separate file,
- Fix positioning of sort button in case when part of the header text is hidden:
Before:
![screenshot from 2018-11-29 12-38-13](https://user-images.githubusercontent.com/15097138/49222488-e9258780-f3d3-11e8-852c-82ab5f6febca.png)
After:
![screenshot from 2018-11-29 12-38-52](https://user-images.githubusercontent.com/15097138/49222504-f3e01c80-f3d3-11e8-9284-8000fbfcb69b.png)
