### PR TITLE
Remove buggy textLength property from sankey-node-component

### DIFF
--- a/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
+++ b/src/components/charts/sankey/sankey-node/sankey-node-component.jsx
@@ -34,7 +34,6 @@ function SankeyNode({ x, y, width, height, index, payload, config }) {
     <Layer key={`CustomNode${index}`}>
       <text
         textAnchor={isOut ? 'start' : 'end'}
-        textLength={rectangleStart}
         className={styles.nodeText}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: tSpans(payload.name) }}


### PR DESCRIPTION
- Remove buggy property `textLength` from sankey-node-component, it causes a bug in flow label on Firefox and it seems to do nothing in Chrome and Safari.
Before fix (Firefox):
![screenshot from 2018-11-29 14-57-09](https://user-images.githubusercontent.com/15097138/49233598-3dd5fc00-f3ee-11e8-9113-c2733e5a164a.png)
