### PR TITLE
Add option to change title style in accordion

### DIFF
--- a/src/components/accordion/accordion-styles.scss
+++ b/src/components/accordion/accordion-styles.scss
@@ -20,8 +20,9 @@
 }
 
 .title {
-  text-align: left;
-  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   padding-right: 30px;
 }
 
@@ -38,9 +39,7 @@
 
 .iconArrow {
   transition: transform 0.25s ease-in-out;
-  position: absolute;
-  right: 10px;
-  top: calc(50% - 5px);
+  margin-left: 10px;
 
   &.isOpen {
     transform: rotate(180deg);

--- a/src/components/accordion/accordion-styles.scss
+++ b/src/components/accordion/accordion-styles.scss
@@ -17,12 +17,12 @@
   &:focus {
     outline: none;
   }
+}
 
-  .title {
-    text-align: left;
-    position: relative;
-    padding-right: 30px;
-  }
+.title {
+  text-align: left;
+  position: relative;
+  padding-right: 30px;
 }
 
 .subHeader {

--- a/src/components/accordion/accordion-theme.scss
+++ b/src/components/accordion/accordion-theme.scss
@@ -3,3 +3,7 @@
 .accordion {
   background-color: $accent-color;
 }
+
+.title {
+  text-align: center;
+}

--- a/src/components/accordion/accordion-theme.scss
+++ b/src/components/accordion/accordion-theme.scss
@@ -5,5 +5,5 @@
 }
 
 .title {
-  text-align: center;
+  justify-content: center;
 }

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -54,7 +54,9 @@ class Accordion extends PureComponent {
                   >
                     <div className={styles.layout}>
                       <div className={cx(styles.title, theme.title)}>
-                        {title}
+                        <span>
+                          {title}
+                        </span>
                         <Icon
                           icon={dropdownArrow}
                           theme={{

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -53,7 +53,7 @@ class Accordion extends PureComponent {
                     onClick={() => handleOnClick(section.slug, isOpen)}
                   >
                     <div className={styles.layout}>
-                      <div className={styles.title}>
+                      <div className={cx(styles.title, theme.title)}>
                         {title}
                         <Icon
                           icon={dropdownArrow}
@@ -117,7 +117,8 @@ Accordion.propTypes = {
   /** Themable options */
   theme: PropTypes.shape({
     wrapper: PropTypes.string,
-    accordion: PropTypes.string
+    accordion: PropTypes.string,
+    title: PropTypes.string
   })
 };
 


### PR DESCRIPTION
- Add theme option to change title style in `Accordion` component
- Change way of positioning elements in accordion's header; use flexbox instead of position relative/absolute
- Update the example

![image](https://user-images.githubusercontent.com/6136899/49879503-69170d00-fe2a-11e8-8347-882b42c16f97.png)

