### PR TITLE
Update carousel component and example

### DIFF
--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -27,10 +27,11 @@ class Carousel extends Component {
       theme,
       hasPaging,
       autoplay,
-      autoplaySpeed
+      autoplaySpeed,
+      primarySlider
     } = this.props;
 
-    const topSliderConfig = {
+    const mainSliderConfig = {
       infinite: true,
       fade: true,
       arrows: false,
@@ -39,44 +40,67 @@ class Carousel extends Component {
       pauseOnHover: true,
       pauseOnDotsHover: true,
       pauseOnFocus: true,
+      slidesToShow: 1,
+      slidesToScroll: 1,
+      beforeChange: (current, next) => this.bottomSlider.slickGoTo(next),
       dots: hasPaging,
       dotsClass: 'cwCarouselPaging',
       speed: 500,
-      slidesToShow: 1,
-      slidesToScroll: 1,
-      customPaging: i => customPaging(i, pagingTitles, theme),
-      beforeChange: (current, next) => this.bottomSlider.slickGoTo(next)
+      customPaging: i => customPaging(i, pagingTitles, theme)
     };
 
-    const bottomSliderConfig = {
+    const secondarySliderConfig = {
       infinite: true,
       arrows: false,
       autoplay: false,
       slidesToShow: 1
     };
 
-    return (
-      <div className={cx(styles.carouselWrapper, theme.carouselWrapper)}>
-        <div
-          className={cx(
+    return primarySlider === 'top'
+      ? (
+        <div className={cx(styles.carouselWrapper, theme.carouselWrapper)}>
+          <div
+            className={cx(
             styles.fadeSliderWithPaging,
             theme.fadeSliderWithPaging
           )}
-        >
-          <Slider {...topSliderConfig}>
-            {children.filter(child => child.props.topSlide)}
-          </Slider>
-        </div>
-        <Slider
-          {...bottomSliderConfig}
-          ref={slider => {
+          >
+            <Slider {...mainSliderConfig}>
+              {children.filter(child => child.props.topSlide)}
+            </Slider>
+          </div>
+          <Slider
+            {...secondarySliderConfig}
+            ref={slider => {
             this.bottomSlider = slider;
           }}
-        >
-          {children.filter(child => child.props.bottomSlide)}
-        </Slider>
-      </div>
-    );
+          >
+            {children.filter(child => child.props.bottomSlide)}
+          </Slider>
+        </div>
+)
+      : (
+        <div className={cx(styles.carouselWrapper, theme.carouselWrapper)}>
+          <Slider
+            {...secondarySliderConfig}
+            ref={slider => {
+            this.bottomSlider = slider;
+          }}
+          >
+            {children.filter(child => child.props.topSlide)}
+          </Slider>
+          <div
+            className={cx(
+            styles.fadeSliderWithPaging,
+            theme.fadeSliderWithPaging
+          )}
+          >
+            <Slider {...mainSliderConfig}>
+              {children.filter(child => child.props.bottomSlide)}
+            </Slider>
+          </div>
+        </div>
+);
   }
 }
 
@@ -87,6 +111,8 @@ Carousel.propTypes = {
   autoplaySpeed: PropTypes.number,
   /** Whether or not to display pagination */
   hasPaging: PropTypes.bool,
+  /** Slider to handle the pagination 'top' or 'bottom' */
+  primarySlider: PropTypes.string,
   /** Array of strings containing slides titles to display on the pagination element.
    * Each string index belongs to the slide with the same index
     */
@@ -106,7 +132,8 @@ Carousel.defaultProps = {
   autoplaySpeed: 4000,
   hasPaging: true,
   pagingTitles: [],
-  theme: {}
+  theme: {},
+  primarySlider: 'top'
 };
 
 export default Carousel;

--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -112,7 +112,7 @@ Carousel.propTypes = {
   /** Whether or not to display pagination */
   hasPaging: PropTypes.bool,
   /** Slider to handle the pagination 'top' or 'bottom' */
-  primarySlider: PropTypes.string,
+  primarySlider: PropTypes.oneOf([ 'top', 'bottom' ]),
   /** Array of strings containing slides titles to display on the pagination element.
    * Each string index belongs to the slide with the same index
     */

--- a/src/components/carousel/carousel.md
+++ b/src/components/carousel/carousel.md
@@ -52,3 +52,58 @@ const CustomBottomSlide = ({empty, withChart}) => !empty && (
   <CustomBottomSlide bottomSlide empty/>
 </Carousel>
 ```
+
+Example with bottom slider as primary slider
+```js
+const image = require('./assets/he.png');
+const pagingTitles = ['Climate goals', 'National context', 'Annual emissions'];
+const width = 400;
+const height = 400;
+const  data = [
+    {id:1, value: 1000, unit: 'MtCO2', color: '#28965A'},
+    {id:2, value: 5700, unit: 'MtCO2', color: '#28965A'},
+    {id:3, value: 89, unit: 'MtCO2', color: '#28965A'},
+    {id:4, value: 54, unit: 'MtCO2', color: '#28965A'},
+    {id:5, value: 330, unit: 'MtCO2', color: '#28965A'},
+    {id:6, value: 9, unit: 'MtCO2', color: '#28965A'},
+    {id:7, value: 320, unit: 'MtCO2', color: '#28965A'},
+    {id:8, value: 76, unit: 'MtCO2', color: '#28965A'}
+  ];
+
+const CustomTopSlide = ({title}) => (
+  <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+    <h3 style={{fontSize: '44px', fontWeight: '300', textAlign: 'center' }}>{title}</h3>
+    <p>
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio.
+    </p>
+    <Button onClick={() => console.info(`Clicked on ${title}`)} >
+      Go to GHG target
+    </Button>
+  </div>
+);
+const CustomBottomSlide = ({empty, withChart}) => !empty && (
+  <div style={{display: 'flex', flexDirection: 'column', margin: '0 auto', maxWidth: '80%', alignItems: 'center'}}>
+    {
+      !withChart &&
+      <img src={image} style={{maxWidth: '100%'}}/>
+    }
+    {
+      withChart &&
+      <BubbleChart
+        width={width}
+        height={height}
+        data={data}
+        handleNodeClick={(e, id) => console.info(`Clicked on element with id: ${id}`)}
+      />
+    }
+  </div>
+);
+<Carousel pagingTitles={pagingTitles} primarySlider='bottom'>
+  <CustomBottomSlide topSlide/>
+  <CustomBottomSlide topSlide withChart/>
+  <CustomBottomSlide topSlide/>
+  <CustomTopSlide title="GHG emissions" bottomSlide/>
+  <CustomTopSlide title="Provinces" bottomSlide/>
+  <CustomTopSlide title="Country" bottomSlide/>
+</Carousel>
+```


### PR DESCRIPTION
This PR updates `Carousel` component to allow changing sliders order.
By passing a `primarySlider` prop (with `'top'`or `'bottom'` value) the slider with the pagination could be changed.

This change is needed to implement CW new homepage design: 
https://projects.invisionapp.com/d/main#/console/16156416/335004355/inspect