### PR TITLE
Fix/table width calculation

### DIFF
--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -14,6 +14,10 @@ $row-column-margin: 10px;
   }
 }
 
+p {
+  margin: 0;
+}
+
 .headerRow,
 .evenRow {
   background-color: $white;

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -142,7 +142,6 @@ p {
   &.ellipsis {
     display: block;
     text-overflow: ellipsis;
-    white-space: nowrap;
   }
 }
 

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -1,8 +1,9 @@
 @import '~styles/settings';
 
 $sort-icon-width: 24px;
-
+$row-column-margin: 10px;
 :export { sorticonwidth: $sort-icon-width; }
+:export { rowcolumnmargin: $row-column-margin; }
 
 .tableWrapper {
   position: relative;
@@ -58,13 +59,13 @@ $sort-icon-width: 24px;
 
   .ReactVirtualized__Table__headerColumn,
   .ReactVirtualized__Table__rowColumn {
-    margin-right: 10px;
+    margin-right: $row-column-margin;
     min-width: 0px;
   }
 
   .ReactVirtualized__Table__headerColumn:first-of-type,
   .ReactVirtualized__Table__rowColumn:first-of-type {
-    margin-left: 10px;
+    margin-left: $row-column-margin;
   }
 
   .ReactVirtualized__Table__rowColumn {
@@ -143,14 +144,14 @@ $sort-icon-width: 24px;
 
 .hasColumnSelect :global {
   .ReactVirtualized__Table__headerRow {
-    padding-left: 30px;
-    margin-left: -30px;
+    padding-left: 15px;
+    margin-left: -15px;
     margin-right: 30px;
   }
 
   .ReactVirtualized__Table__row {
-    padding-left: 30px;
-    margin-left: -30px;
+    padding-left: 15px;
+    margin-left: -15px;
     margin-right: 30px;
   }
 }

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -42,6 +42,11 @@ class Table extends PureComponent {
     this.minRowHeight = 80;
     this.rowHeightWithEllipsis = 150;
     this.virtualizedTable = React.createRef();
+    this.arrowWidth = parseInt(styles.sorticonwidth.replace('px', ''), 10);
+    this.rowColumnMargin = parseInt(
+      styles.rowcolumnmargin.replace('px', ''),
+      10
+    );
   }
 
   componentWillReceiveProps(nextProps) {
@@ -67,8 +72,9 @@ class Table extends PureComponent {
     const columnsLenght = columns.length;
     if (columnsLenght === 1) return width;
     const totalWidth = columns.reduce(
-      (acc, column) => acc + this.getColumnLength(data, column.label),
-      0
+      (acc, column) =>
+        acc + this.getColumnLength(data, column.label) + this.rowColumnMargin,
+      this.rowColumnMargin
     );
     return totalWidth < width ? width : totalWidth;
   };
@@ -148,8 +154,8 @@ class Table extends PureComponent {
       column
     );
     const length = meanLenght * this.lengthWidthRatio;
-    const arrowPadding = 8;
-    const columnTitleLength = (column.length + arrowPadding) *
+    // const arrowPadding = this.arrowWidth;
+    const columnTitleLength = (column.length + this.arrowWidth) *
       this.lengthWidthRatio;
 
     if (length < this.minColumnWidth) return this.minColumnWidth;
@@ -227,8 +233,7 @@ class Table extends PureComponent {
 
     const getHeaderLabel = (columnText, columnData) => {
       const { width } = this.columnWidthProps(columnText, columnData);
-      const sortIconWidth = styles.sorticonwidth.replace('px', '');
-      const truncateWidth = width - sortIconWidth;
+      const truncateWidth = width - this.arrowWidth;
       return (
         <Truncate
           data-for="header-label"

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -74,7 +74,7 @@ class Table extends PureComponent {
     const totalWidth = columns.reduce(
       (acc, column) =>
         acc + this.getColumnLength(data, column.label) + this.rowColumnMargin,
-      this.rowColumnMargin
+      this.rowColumnMargin + 10
     );
     return totalWidth < width ? width : totalWidth;
   };
@@ -154,7 +154,6 @@ class Table extends PureComponent {
       column
     );
     const length = meanLenght * this.lengthWidthRatio;
-    // const arrowPadding = this.arrowWidth;
     const columnTitleLength = (column.length + this.arrowWidth) *
       this.lengthWidthRatio;
 
@@ -196,6 +195,7 @@ class Table extends PureComponent {
       optionsOpen
     } = this.state;
     const {
+      data: propsData,
       hasColumnSelect,
       tableHeight,
       headerHeight,
@@ -284,7 +284,7 @@ class Table extends PureComponent {
             {({ width }) => (
               <VirtualizedTable
                 className={styles.table}
-                width={this.getFullWidth(data, activeColumns, width)}
+                width={this.getFullWidth(propsData, activeColumns, width)}
                 height={tableHeight}
                 headerHeight={headerHeight}
                 rowClassName={this.rowClassName}


### PR DESCRIPTION
This fix should prevent from clipping columns in table component:
![untitled](https://user-images.githubusercontent.com/15097138/50096580-f59d4300-020f-11e9-93b2-e8a3f17ac2ef.png)
- This issue is fixed mainly by changing `data` source from `state` to `data` from `props` for full-width calculation:
![screenshot from 2018-12-17 15-27-49](https://user-images.githubusercontent.com/15097138/50096922-a6a3dd80-0210-11e9-94aa-951f8a507f39.png)

I'm not really sure what is the real difference, because both sources are using in the component.
- Also included sort button width and margin between columns in full-width calculation,

After release, I'll check it again with other tables in SA