### PR TITLE
Updated sliding logic

### DIFF
--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -42,7 +42,7 @@ class Carousel extends Component {
       pauseOnFocus: true,
       slidesToShow: 1,
       slidesToScroll: 1,
-      beforeChange: (current, next) => this.bottomSlider.slickGoTo(next),
+      beforeChange: (current, next) => this.secondarySlider.slickGoTo(next),
       dots: hasPaging,
       dotsClass: 'cwCarouselPaging',
       speed: 500,
@@ -53,7 +53,8 @@ class Carousel extends Component {
       infinite: true,
       arrows: false,
       autoplay: false,
-      slidesToShow: 1
+      slidesToShow: 1,
+      beforeChange: (current, next) => this.mainSlider.slickGoTo(next)
     };
 
     return primarySlider === 'top'
@@ -65,14 +66,19 @@ class Carousel extends Component {
             theme.fadeSliderWithPaging
           )}
           >
-            <Slider {...mainSliderConfig}>
+            <Slider
+              {...mainSliderConfig}
+              ref={slider => {
+              this.mainSlider = slider;
+            }}
+            >
               {children.filter(child => child.props.topSlide)}
             </Slider>
           </div>
           <Slider
             {...secondarySliderConfig}
             ref={slider => {
-            this.bottomSlider = slider;
+            this.secondarySlider = slider;
           }}
           >
             {children.filter(child => child.props.bottomSlide)}
@@ -84,7 +90,7 @@ class Carousel extends Component {
           <Slider
             {...secondarySliderConfig}
             ref={slider => {
-            this.bottomSlider = slider;
+            this.secondarySlider = slider;
           }}
           >
             {children.filter(child => child.props.topSlide)}
@@ -95,7 +101,12 @@ class Carousel extends Component {
             theme.fadeSliderWithPaging
           )}
           >
-            <Slider {...mainSliderConfig}>
+            <Slider
+              {...mainSliderConfig}
+              ref={slider => {
+              this.mainSlider = slider;
+            }}
+            >
               {children.filter(child => child.props.bottomSlide)}
             </Slider>
           </div>


### PR DESCRIPTION
This PR fixes an issue on `Carousel` component.
Now 'clicking and dragging' on any of the slides (top or bottom) will update the other.

![kapture 2018-12-18 at 18 10 20](https://user-images.githubusercontent.com/6906348/50170465-3a98a680-02f0-11e9-8a94-371e04d4570c.gif)
