### PR TITLE
Feature/chart hidden data columns

### DIFF
--- a/src/components/charts/assets/data.js
+++ b/src/components/charts/assets/data.js
@@ -105,9 +105,9 @@ export const data = [
     yCo2: 24697808420,
     yCh4: 6260373623,
     yFGas: 262076768.3,
-    yOthersGas1: 3062076768.3,
-    yOthersGas2: 2025076768.3,
-    yOthers: 5025076768.3
+    yOthersGas1: 3000000000,
+    yOthersGas2: 2000000000,
+    yOthers: 5000000000
   },
   {
     x: 1991,
@@ -120,9 +120,9 @@ export const data = [
     yCh4: 6250436642,
     yN2O: 2593531229,
     yFGas: 267832161.6,
-    yOthersGas1: 3062076768.3,
-    yOthersGas2: 2025076768.3,
-    yOthers: 5025076768.3
+    yOthersGas1: 3000000000,
+    yOthersGas2: 2000000000,
+    yOthers: 5000000000
   },
   {
     x: 1992,

--- a/src/components/charts/assets/data.js
+++ b/src/components/charts/assets/data.js
@@ -17,7 +17,10 @@ export const config = {
     yFGas: { stroke: '#FF7800', fill: '#FF7800' },
     ppd: { stroke: '#3498db', fill: '#d6eaf8' },
     bau: { stroke: '#f5b335', fill: '#fdf0d7' },
-    ltms: { stroke: '#f97da1', fill: '#f97da1' }
+    ltms: { stroke: '#f97da1', fill: '#f97da1' },
+    yOthersGas1: { stroke: '#ccc', fill: '#ccc' },
+    yOthersGas2: { stroke: '#ccc', fill: '#ccc' },
+    yOthers: { stroke: '#ccc', fill: '#ccc' }
   },
   tooltip: {
     yAllGhg: { label: 'All GHG' },
@@ -28,7 +31,8 @@ export const config = {
     yCo2: { label: 'CO2' },
     yCh4: { label: 'CH4' },
     yN2O: { label: 'N2O' },
-    yFGas: { label: 'F-Gas' }
+    yFGas: { label: 'F-Gas' },
+    yOthers: { label: 'Others' }
   },
   animation: false,
   columns: {
@@ -38,7 +42,10 @@ export const config = {
       { label: 'CO2', value: 'yCo2' },
       { label: 'CH4', value: 'yCh4' },
       { label: 'N2O', value: 'yN2O' },
-      { label: 'F-Gas', value: 'yFGas' }
+      { label: 'F-Gas', value: 'yFGas' },
+      { label: 'Gas1', value: 'yOthersGas1', hideLegend: true },
+      { label: 'Gas2', value: 'yOthersGas2', hideLegend: true },
+      { label: 'Others', value: 'yOthers', hideData: true }
     ],
     z: [ { label: 'GHG Inventory', value: 'ghgInventory' } ],
     w: [ { label: 'ppd', value: 'ppd' }, { label: 'BaU', value: 'bau' } ],
@@ -51,7 +58,10 @@ export const initialYColumns = [
   { label: 'CO2', value: 'yCo2' },
   { label: 'CH4', value: 'yCh4' },
   { label: 'N2O', value: 'yN2O' },
-  { label: 'F-Gas', value: 'yFGas' }
+  { label: 'F-Gas', value: 'yFGas' },
+  { label: 'Gas1', value: 'yOthersGas1' },
+  { label: 'Gas2', value: 'yOthersGas2' },
+  { label: 'Others', value: 'yOthers', hideData: true }
 ];
 
 export const initialWColumns = [
@@ -65,6 +75,25 @@ export const initialZColumns = [
 
 export const initialTColumns = [ { label: 'LTMs', value: 'ltms' } ];
 
+export const domain = { x: [ 'auto', 'auto' ], y: [ null, 'auto' ] };
+
+export const filters = [
+  { value: 13, label: 'All GHG' },
+  { value: 15, label: 'CH4' },
+  { value: 14, label: 'CO2' },
+  { value: 17, label: 'F-Gas' },
+  { value: 16, label: 'N2O' },
+  { value: 17, label: 'Others' }
+];
+
+export const filtersSelected = [
+  { value: 13, label: 'All GHG' },
+  { value: 15, label: 'CH4' },
+  { value: 14, label: 'CO2' },
+  { value: 16, label: 'N2O' },
+  { value: 17, label: 'Others' }
+];
+
 export const data = [
   {
     x: 1990,
@@ -75,7 +104,10 @@ export const data = [
     ghgInventory: 7260373623,
     yCo2: 24697808420,
     yCh4: 6260373623,
-    yFGas: 262076768.3
+    yFGas: 262076768.3,
+    yOthersGas1: 3062076768.3,
+    yOthersGas2: 2025076768.3,
+    yOthers: 5025076768.3
   },
   {
     x: 1991,
@@ -87,7 +119,10 @@ export const data = [
     yCo2: 24896694270,
     yCh4: 6250436642,
     yN2O: 2593531229,
-    yFGas: 267832161.6
+    yFGas: 267832161.6,
+    yOthersGas1: 3062076768.3,
+    yOthersGas2: 2025076768.3,
+    yOthers: 5025076768.3
   },
   {
     x: 1992,
@@ -331,21 +366,4 @@ export const data = [
     yN2O: 3049932441,
     yFGas: 874078563.9
   }
-];
-
-export const domain = { x: [ 'auto', 'auto' ], y: [ null, 'auto' ] };
-
-export const filters = [
-  { value: 13, label: 'All GHG' },
-  { value: 15, label: 'CH4' },
-  { value: 14, label: 'CO2' },
-  { value: 17, label: 'F-Gas' },
-  { value: 16, label: 'N2O' }
-];
-
-export const filtersSelected = [
-  { value: 13, label: 'All GHG' },
-  { value: 15, label: 'CH4' },
-  { value: 14, label: 'CO2' },
-  { value: 16, label: 'N2O' }
 ];

--- a/src/components/charts/assets/data.js
+++ b/src/components/charts/assets/data.js
@@ -43,8 +43,18 @@ export const config = {
       { label: 'CH4', value: 'yCh4' },
       { label: 'N2O', value: 'yN2O' },
       { label: 'F-Gas', value: 'yFGas' },
-      { label: 'Gas1', value: 'yOthersGas1', hideLegend: true },
-      { label: 'Gas2', value: 'yOthersGas2', hideLegend: true },
+      {
+        label: 'Gas1',
+        value: 'yOthersGas1',
+        hideLegend: true,
+        legendColumn: 'Others'
+      },
+      {
+        label: 'Gas2',
+        value: 'yOthersGas2',
+        hideLegend: true,
+        legendColumn: 'Others'
+      },
       { label: 'Others', value: 'yOthers', hideData: true }
     ],
     z: [ { label: 'GHG Inventory', value: 'ghgInventory' } ],
@@ -59,8 +69,18 @@ export const initialYColumns = [
   { label: 'CH4', value: 'yCh4' },
   { label: 'N2O', value: 'yN2O' },
   { label: 'F-Gas', value: 'yFGas' },
-  { label: 'Gas1', value: 'yOthersGas1' },
-  { label: 'Gas2', value: 'yOthersGas2' },
+  {
+    label: 'Gas1',
+    value: 'yOthersGas1',
+    hideLegend: true,
+    legendColumn: 'Others'
+  },
+  {
+    label: 'Gas2',
+    value: 'yOthersGas2',
+    hideLegend: true,
+    legendColumn: 'Others'
+  },
   { label: 'Others', value: 'yOthers', hideData: true }
 ];
 
@@ -83,7 +103,7 @@ export const filters = [
   { value: 14, label: 'CO2' },
   { value: 17, label: 'F-Gas' },
   { value: 16, label: 'N2O' },
-  { value: 17, label: 'Others' }
+  { value: 18, label: 'Others' }
 ];
 
 export const filtersSelected = [
@@ -91,7 +111,7 @@ export const filtersSelected = [
   { value: 15, label: 'CH4' },
   { value: 14, label: 'CO2' },
   { value: 16, label: 'N2O' },
-  { value: 17, label: 'Others' }
+  { value: 18, label: 'Others' }
 ];
 
 export const data = [

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -10,7 +10,10 @@ initialState = {
 const handleLegendChange = (filtersSelected) => {
   setState(state => {
     const filterIds = filtersSelected.map(f => f.label);
-    const filteredColumns = data.initialYColumns.filter(col => filterIds.includes(col.label));
+    const filteredColumns = data.initialYColumns.filter(col =>
+      filterIds.includes(col.label) ||
+      (col.hideLegend && filterIds.includes(col.legendColumn))
+    );
     const config = {...state.config};
     config.columns.y = filteredColumns;
     return {
@@ -63,7 +66,10 @@ const chartTypes = ['line', 'area', 'percentage'];
 const handleLegendChange = (filtersSelected) => {
   setState(state => {
     const filterIds = filtersSelected.map(f => f.label);
-    const filteredColumns = data.initialYColumns.filter(col => filterIds.includes(col.label));
+    const filteredColumns = data.initialYColumns.filter(col =>
+      filterIds.includes(col.label) ||
+      (col.hideLegend && filterIds.includes(col.legendColumn))
+    );
     const config = {...state.config};
     config.columns.y = filteredColumns;
     return {
@@ -118,7 +124,10 @@ const chartTypes = ['line', 'area', 'percentage'];
 const handleLegendChange = (filtersSelected) => {
   setState(state => {
     const filterIds = filtersSelected.map(f => f.label);
-    const filteredColumns = data.initialYColumns.filter(col => filterIds.includes(col.label));
+    const filteredColumns = data.initialYColumns.filter(col =>
+      filterIds.includes(col.label) ||
+      (col.hideLegend && filterIds.includes(col.legendColumn))
+    );
     const config = {...state.config};
     config.columns.y = filteredColumns;
     return {

--- a/src/components/charts/legend-chart/legend-chart.js
+++ b/src/components/charts/legend-chart/legend-chart.js
@@ -53,10 +53,8 @@ class LegendChart extends PureComponent {
           column => dataSelectedIds.includes(column.label)
         )
         : [];
-
     let filteredColumns = columnKeys.map(key => filterColumns(key));
     filteredColumns = [].concat(...filteredColumns);
-
     const hasLegendNote = config && config.legendNote;
 
     const columnsLength = filteredColumns.length;

--- a/src/components/charts/line/line.js
+++ b/src/components/charts/line/line.js
@@ -156,10 +156,14 @@ class ChartLine extends PureComponent {
                     isAnimationActive={
                       isUndefined(config.animation) ? true : config.animation
                     }
-                    dot={dots && { strokeWidth: 0, fill: color, radius: 0.5 }}
+                    dot={
+                      dots &&
+                        !column.hideData &&
+                        { strokeWidth: 0, fill: color, radius: 0.5 }
+                    }
                     dataKey={column.value}
-                    stroke={color}
-                    strokeWidth={2}
+                    stroke={column.hideData ? 'transparent' : color}
+                    strokeWidth={column.hideData ? 0 : 2}
                     type={lineType}
                   />
                 );

--- a/src/components/charts/percentage/percentage-selectors.js
+++ b/src/components/charts/percentage/percentage-selectors.js
@@ -7,16 +7,17 @@ export const getData = createSelector([ selectData, state => state.config ], (
 ) =>
   {
     if (!data || !config) return null;
+
     return data.map(d => {
-      const updatedD = { ...d };
+      const updatedD = {};
       let total = 0;
-      config.columns.y.forEach(key => {
-        if (d[key.value]) total += d[key.value];
+      const columns = config.columns.y.filter(c => !c.hideData);
+      columns.forEach(column => {
+        if (d[column.value]) total += d[column.value];
       });
-      config.columns.y.map(key => {
-        updatedD[key.value] = total ? d[key.value] / total * 100 : null;
-        return updatedD[key.value];
+      columns.forEach(column => {
+        updatedD[column.value] = total ? d[column.value] / total * 100 : null;
       });
-      return updatedD;
+      return { x: d.x, ...updatedD };
     });
   });

--- a/src/components/charts/percentage/percentage-selectors.js
+++ b/src/components/charts/percentage/percentage-selectors.js
@@ -1,23 +1,35 @@
 import { createSelector } from 'reselect';
 
 const selectData = state => state.data || null;
+const calculateData = (data, columns) => data.map(d => {
+  const updatedD = {};
+  let total = 0;
+  columns.forEach(column => {
+    if (d[column.value]) total += d[column.value];
+  });
+  columns.forEach(column => {
+    updatedD[column.value] = total ? d[column.value] / total * 100 : null;
+  });
+  return { x: d.x, ...updatedD, total };
+});
+
 export const getData = createSelector([ selectData, state => state.config ], (
   data,
   config
 ) =>
   {
     if (!data || !config) return null;
-
-    return data.map(d => {
-      const updatedD = {};
-      let total = 0;
-      const columns = config.columns.y.filter(c => !c.hideData);
-      columns.forEach(column => {
-        if (d[column.value]) total += d[column.value];
-      });
-      columns.forEach(column => {
-        updatedD[column.value] = total ? d[column.value] / total * 100 : null;
-      });
-      return { x: d.x, ...updatedD };
-    });
+    const columns = config.columns.y.filter(c => !c.hideData);
+    return calculateData(data, columns);
   });
+
+export const getTooltipData = createSelector(
+  [ selectData, state => state.config ],
+  (data, config) => {
+    if (!data || !config) return null;
+    const hiddenDataColumns = config.columns.y.filter(c => !c.hideData);
+    if (!hiddenDataColumns) return null;
+    const columns = config.columns.y.filter(c => !c.hideLegend);
+    return calculateData(data, columns);
+  }
+);

--- a/src/components/charts/percentage/percentage.js
+++ b/src/components/charts/percentage/percentage.js
@@ -15,7 +15,7 @@ import {
 import TooltipChart from 'components/charts/tooltip-chart';
 import { format } from 'd3-format';
 import yAxisLabel from 'components/charts/y-axis-label';
-import { getData } from './percentage-selectors';
+import { getData, getTooltipData } from './percentage-selectors';
 import { CustomXAxisTick, CustomYAxisTick } from './axis-ticks';
 
 class ChartPercentage extends PureComponent {
@@ -44,6 +44,20 @@ class ChartPercentage extends PureComponent {
     }
   };
 
+  addHiddenData = (content, tooltipData) => {
+    const updatedContent = { ...content };
+    if (!tooltipData) return content;
+    return {
+      ...updatedContent,
+      payload: updatedContent.payload.map(c => {
+        const updatedC = { ...c };
+        if (!c.payload) return c;
+        updatedC.payload = tooltipData.find(t => c.payload.x === t.x);
+        return updatedC;
+      })
+    };
+  };
+
   render() {
     const { tooltipVisibility } = this.state;
     const {
@@ -58,6 +72,7 @@ class ChartPercentage extends PureComponent {
     } = this.props;
     const percentageState = { data, config };
     const percentageData = getData(percentageState);
+    const tooltipData = getTooltipData(percentageState);
     const updatedConfig = {
       ...config,
       axes: {
@@ -118,7 +133,7 @@ class ChartPercentage extends PureComponent {
                       }) ||
                       (
                         <TooltipChart
-                          content={content}
+                          content={this.addHiddenData(content, tooltipData)}
                           config={updatedConfig}
                           showTotal
                           getCustomYLabelFormat={getTooltipLabelFormat}

--- a/src/components/charts/selectors/chart-selectors.js
+++ b/src/components/charts/selectors/chart-selectors.js
@@ -10,10 +10,10 @@ export const getDataWithTotal = createSelector(
     if (!data || !config) return null;
     return data.map(d => {
       let total = null;
-      config.columns.y.forEach(key => {
-        if (d[key.value]) {
+      config.columns.y.forEach(column => {
+        if (d[column.value] && !column.hideData) {
           if (!total) total = 0;
-          total += d[key.value];
+          total += d[column.value];
         }
       });
       return { ...d, total };

--- a/src/components/charts/stacked-area/stacked-area.js
+++ b/src/components/charts/stacked-area/stacked-area.js
@@ -219,12 +219,15 @@ class ChartStackedArea extends PureComponent {
                   dataKey={column.value}
                   dot={false}
                   stackId={1}
-                  stroke={'transparent' || ''}
+                  stroke="transparent"
                   strokeWidth={0}
                   isAnimationActive={
                     isUndefined(config.animation) ? true : config.animation
                   }
-                  fill={config.theme[column.value].fill || ''}
+                  fill={
+                    !column.hideData && config.theme[column.value].fill ||
+                      'transparent'
+                  }
                   type={stepped ? 'step' : 'linear'}
                 />
               ))

--- a/src/components/charts/tooltip-chart/tooltip-chart.js
+++ b/src/components/charts/tooltip-chart/tooltip-chart.js
@@ -116,13 +116,13 @@ class TooltipChart extends PureComponent {
           content &&
             content.payload &&
             content.payload.length > 0 &&
-            this.sortByValue(content.payload, config).map(y => {
+            this.sortByValue(content.payload).map(y => {
               const hasDataKey = !!y.dataKey;
               const labelName = y.dataKey || y.name;
               return y.payload &&
                 y.dataKey !== 'total' &&
                 (hasDataKey
-                  ? config.tooltip[labelName].label
+                  ? config.tooltip[labelName] && config.tooltip[labelName].label
                   : config.tooltip[labelName])
                 ? (
                   <div key={`${labelName}`} className={styles.label}>


### PR DESCRIPTION
This PR solves the special case in which some columns shouldn't be displayed in the data and some others in the legend.

This happens for example in the GHG emissions redesign, where we have the 'Others' column that should be subdivided in the data chart into different lines of data but it should appear in the legend and tooltip just as the 'Others' aggregation.

To solve this I have created some columns that have the `hideData: true` attribute  and others that have the `hideLegend: true`

Just for the example, the ones that have the legend and tooltip hidden will also have a     `legendColumn` attribute that will specify their parent column.

![image](https://user-images.githubusercontent.com/9701591/50231753-cd4c4a80-03af-11e9-8f08-e35fde4367be.png)
