### PR TITLE
Alternative way to display hidden data to avoid current display problems

### DIFF
--- a/src/components/charts/stacked-area/stacked-area.js
+++ b/src/components/charts/stacked-area/stacked-area.js
@@ -100,6 +100,24 @@ class ChartStackedArea extends PureComponent {
     }
   };
 
+  addHiddenColumns = content => {
+    const { data, config } = this.props;
+    const hiddenColumns = config.columns.y.filter(c => c.hideData);
+    if (!hiddenColumns || !data || content.payload.length === 0) return content;
+    const updatedContent = { ...content };
+    const extraContent = hiddenColumns.map(c => ({ ...c, name: c.value }));
+    const year = updatedContent.payload[0].payload.x;
+    const payload = updatedContent.payload.concat(extraContent).map(c => {
+      const updatedC = { ...c };
+      if (!c.payload && !hiddenColumns.map(col => col.value).includes(c.name))
+        return c;
+      updatedC.payload = data.find(t => year === t.x);
+      return updatedC;
+    });
+    const d = { ...updatedContent, payload };
+    return d;
+  };
+
   render() {
     const { tooltipVisibility, showLastPoint, activePoint } = this.state;
     const {
@@ -201,7 +219,7 @@ class ChartStackedArea extends PureComponent {
                       React.cloneElement(customTooltip, { content, config }) ||
                       (
                         <TooltipChart
-                          content={content}
+                          content={this.addHiddenColumns(content)}
                           config={config}
                           showTotal
                           getCustomYLabelFormat={getCustomYLabelFormat}
@@ -212,25 +230,26 @@ class ChartStackedArea extends PureComponent {
               )
           }
           {
-            config.columns &&
-              config.columns.y.map(column => (
-                <Area
-                  key={column.value}
-                  dataKey={column.value}
-                  dot={false}
-                  stackId={1}
-                  stroke="transparent"
-                  strokeWidth={0}
-                  isAnimationActive={
-                    isUndefined(config.animation) ? true : config.animation
-                  }
-                  fill={
-                    !column.hideData && config.theme[column.value].fill ||
-                      'transparent'
-                  }
-                  type={stepped ? 'step' : 'linear'}
-                />
-              ))
+            config.columns && config.columns.y
+                .filter(c => !c.hideData)
+                .map(column => (
+                  <Area
+                    key={column.value}
+                    dataKey={column.value}
+                    dot={false}
+                    stackId={1}
+                    stroke="transparent"
+                    strokeWidth={0}
+                    isAnimationActive={
+                      isUndefined(config.animation) ? true : config.animation
+                    }
+                    fill={
+                      !column.hideData && config.theme[column.value].fill ||
+                        'transparent'
+                    }
+                    type={stepped ? 'step' : 'linear'}
+                  />
+                ))
           }
           {
             includeTotalLine &&


### PR DESCRIPTION
This PR finds an alternative way to display hidden data in the stacked chart. There were some display problems in CW GHG emissions where the data was being rendered as transparent and stacking although we didn't want it to show at all. Now the hiddenData columns are filtered from the chart data and added as extra content for the tooltip. Its the same procedure we have in the percentage chart. This last function is a bit cumbersome but I couldn't find other solution. 

There are no visible changes in the storybook display.

![image](https://user-images.githubusercontent.com/9701591/50447010-95e21e80-0918-11e9-8773-6b170fc7a339.png)
