### PR TITLE
Fix rendering bars in bar chart

### DIFF
--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -66,7 +66,9 @@ class SimpleBarChart extends PureComponent {
       : undefined;
 
     const LineChartMargin = { top: 10, right: 0, left: -10, bottom: 0 };
-    const dataKeys = Object.keys(config.columns).filter(col => col !== 'x');
+    const dataKeys = config.columns.y
+      .map(o => o.value)
+      .filter(col => col !== 'x');
 
     return (
       <div>

--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -67,9 +67,7 @@ class SimpleBarChart extends PureComponent {
       : undefined;
 
     const LineChartMargin = { top: 10, right: 0, left: -10, bottom: 0 };
-    const dataKeys = config.columns.y
-      .map(o => o.value)
-      .filter(col => col !== 'x');
+    const dataKeys = config.columns.y.map(o => o.value);
 
     return (
       <div>

--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -46,7 +46,8 @@ class SimpleBarChart extends PureComponent {
       customYAxisTick,
       customTooltip,
       getCustomYLabelFormat,
-      barSize
+      barSize,
+      barGap
     } = this.props;
 
     const yUnit = showUnit && has(config, 'axes.yLeft.unit')
@@ -74,6 +75,7 @@ class SimpleBarChart extends PureComponent {
       <div>
         <ResponsiveContainer height={height} margin={margin}>
           <BarChart
+            barGap={barGap}
             data={data}
             margin={LineChartMargin}
             height={height}
@@ -158,7 +160,9 @@ SimpleBarChart.propTypes = {
   customYAxisTick: PropTypes.node,
   customTooltip: PropTypes.node,
   getCustomYLabelFormat: PropTypes.func,
-  barSize: PropTypes.number
+  barSize: PropTypes.number,
+  /** Bar gap between bars if there are multiple bars per one x value */
+  barGap: PropTypes.number
 };
 
 SimpleBarChart.defaultProps = {
@@ -175,7 +179,8 @@ SimpleBarChart.defaultProps = {
   customYAxisTick: null,
   customTooltip: null,
   getCustomYLabelFormat: null,
-  barSize: undefined
+  barSize: undefined,
+  barGap: undefined
 };
 
 export default SimpleBarChart;

--- a/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-component.jsx
+++ b/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-component.jsx
@@ -62,7 +62,7 @@ class BarTooltipChart extends PureComponent {
                         <span
                           className={styles.unit}
                           /* eslint-disable-line*/
-                          dangerouslySetInnerHTML={{ __html: yUnit }}
+                          dangerouslySetInnerHTML={{ __html: config.tooltip[y.dataKey].label }}
                         />
                       )}
                       <span>

--- a/src/components/charts/bar-chart/data-for-multiple-bars.js
+++ b/src/components/charts/bar-chart/data-for-multiple-bars.js
@@ -1,0 +1,37 @@
+export const data = [
+  { x: '0-4', y: 8090282, yTwo: 8090320 },
+  { x: '5-9', y: 8890282, yTwo: 889000 },
+  { x: '10-14', y: 8090282, yTwo: 8890140 },
+  { x: '15-18', y: 8000282, yTwo: 8890100 },
+  { x: '19-24', y: 9090282, yTwo: 8890400 },
+  { x: '25-29', y: 8090282, yTwo: 8890200 }
+];
+
+export const domain = { x: [ 'auto', 'auto' ], y: [ 0, 'auto' ] };
+
+export const config = {
+  axes: {
+    xBottom: {
+      name: 'Age distribution',
+      unit: 'age',
+      format: 'string',
+      label: { dx: 0, dy: 0, className: '' }
+    },
+    yLeft: {
+      name: 'Number of people',
+      unit: 'people',
+      format: 'number',
+      label: { dx: 2, dy: 14, className: '' }
+    }
+  },
+  tooltip: { y: { label: 'people' }, yTwo: { label: 'not people' } },
+  animation: false,
+  columns: {
+    x: [ { label: 'year', value: 'x' } ],
+    y: [ { label: '', value: 'y' }, { label: '', value: 'yTwo' } ]
+  },
+  theme: {
+    y: { stroke: '', fill: '#f5b335' },
+    yTwo: { stroke: '', fill: '#00B4D2' }
+  }
+};

--- a/src/components/charts/chart/chart.js
+++ b/src/components/charts/chart/chart.js
@@ -171,7 +171,9 @@ Chart.propTypes = {
   /** Function transforming y axis value */
   getCustomYLabelFormat: PropTypes.func,
   /** Specific for bar chart - single bar size */
-  barSize: PropTypes.number
+  barSize: PropTypes.number,
+  /** Specific for bar chart - gap between bars in case there are multiple bars per one x value */
+  barGap: PropTypes.number
 };
 
 Chart.defaultProps = {
@@ -194,7 +196,8 @@ Chart.defaultProps = {
   customYAxisTick: null,
   customTooltip: null,
   getCustomYLabelFormat: null,
-  barSize: undefined
+  barSize: undefined,
+  barGap: undefined
 };
 
 export default Chart;

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -192,3 +192,29 @@ const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
   />
 </React.Fragment>
 ```
+
+Example with bar chart with multiple bars
+```js
+const data = require('../bar-chart/data-for-multiple-bars.js');
+const format = require('d3-format').format;
+initialState = {
+  ...data,
+  type: 'bar',
+  loading: false
+};
+const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
+<React.Fragment>
+  <Chart
+    type={state.type}
+    config={state.config}
+    data={state.data}
+    domain={state.domain}
+    height={500}
+    loading={state.loading}
+    getCustomYLabelFormat={getCustomYLabelFormat}
+    barSize={40}
+    showUnit
+  />
+</React.Fragment>
+```
+

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -213,6 +213,7 @@ const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
     loading={state.loading}
     getCustomYLabelFormat={getCustomYLabelFormat}
     barSize={40}
+    barGap={0}
     showUnit
   />
 </React.Fragment>


### PR DESCRIPTION
There was a problem with rendering multiple bars for one `x` in BarChart component. Multiple bars for one `x` meaning as so:
![image](https://user-images.githubusercontent.com/6136899/51049998-54fc3200-15c7-11e9-9d44-3cdfe5c43d3e.png)

Add example to the showcase with rendering multiple bars in a BarChart:
![image](https://user-images.githubusercontent.com/6136899/51051250-2da76400-15cb-11e9-845b-5f4d0be8bde0.png)

Fix tooltip for a BarChart:
![image](https://user-images.githubusercontent.com/6136899/51051301-53346d80-15cb-11e9-896a-bf15f80b6712.png)
Before it was taking label from `unit`, not from label per each `y` key.

Add a `barGap` prop to a BarChart to specify a gap between bars in case there are multiple ones per one x value.