### PR TITLE
Make y labels font size smaller to avoid text clipping on bigger texts

### DIFF
--- a/src/components/charts/bar-chart/axis-ticks.js
+++ b/src/components/charts/bar-chart/axis-ticks.js
@@ -37,7 +37,7 @@ export const CustomYAxisTick = (
           textAnchor="end"
           stroke="#b1b1c1"
           strokeWidth="0.5"
-          fontSize="13px"
+          fontSize="11px"
         >
           {
             index === 0 &&


### PR DESCRIPTION
This PR decreases y label font size by 2px to avoid text clipping when the value is bigger.

![image](https://user-images.githubusercontent.com/6136899/51177691-37c1af00-18b8-11e9-9afe-a824c576cf46.png)
