### PR TITLE
Add reverse flag to Card component to change the order of rendering

### DIFF
--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -8,29 +8,49 @@ import styles from './card-styles.scss';
  * Represents a card with title and description
  */
 class Card extends PureComponent {
+  renderContent = () => {
+    const { title, subtitle, theme } = this.props;
+
+    return (
+      <div className={cx(styles.contentContainer, theme.contentContainer)}>
+        {
+          title && (
+          <p className={cx(styles.title, theme.title)}>
+            {title}
+          </p>
+            )
+        }
+        {
+          subtitle && (
+          <p className={cx(styles.subtitle, theme.subtitle)}>
+            {subtitle}
+          </p>
+            )
+        }
+      </div>
+    );
+  };
+
+  renderChildren = () => {
+    const { children, theme } = this.props;
+
+    return (
+      <div className={cx(styles.data, theme.data)}>
+        {children}
+      </div>
+    );
+  };
+
   render() {
-    const { title, children, subtitle, theme } = this.props;
+    const { theme, reverse } = this.props;
+
     return (
       <div className={cx(styles.card, theme.card)}>
-        <div className={cx(styles.data, theme.data)}>
-          {children}
-        </div>
-        <div className={cx(styles.contentContainer, theme.contentContainer)}>
-          {
-            title && (
-            <p className={cx(styles.title, theme.title)}>
-              {title}
-            </p>
-              )
-          }
-          {
-            subtitle && (
-            <p className={cx(styles.subtitle, theme.subtitle)}>
-              {subtitle}
-            </p>
-              )
-          }
-        </div>
+        {
+          reverse
+            ? [ this.renderContent(), this.renderChildren() ]
+            : [ this.renderChildren(), this.renderContent() ]
+        }
       </div>
     );
   }
@@ -40,6 +60,7 @@ Card.propTypes = {
   title: PropTypes.string,
   subtitle: PropTypes.string,
   children: PropTypes.node.isRequired,
+  reverse: PropTypes.bool,
   theme: PropTypes.shape({
     card: PropTypes.string,
     title: PropTypes.string,
@@ -49,6 +70,6 @@ Card.propTypes = {
   })
 };
 
-Card.defaultProps = { theme: {}, title: '', subtitle: '' };
+Card.defaultProps = { theme: {}, title: '', subtitle: '', reverse: false };
 
 export default Card;

--- a/src/components/card/card.md
+++ b/src/components/card/card.md
@@ -7,3 +7,14 @@ const styles = require('./card-styles.scss');
     </div>
 </Card>
 ```
+
+Example with first rendering the title on the Card and then the children.
+Possible when passing *reverse* flag set to true.
+```js
+const styles = require('./card-styles.scss');
+<Card title='Card' reverse theme={styles} subtitle='sub title'>
+    <div className={styles.cardContent}>
+        Have an IMPACT!
+    </div>
+</Card>
+```


### PR DESCRIPTION
Add a `reverse` flag to Card component to change the order of rendering header/content.
Add example to the showcase:

![image](https://user-images.githubusercontent.com/6136899/51258371-bc3c2c80-19a1-11e9-83bb-1539f6e600be.png)
