### PR TITLE
Add new config props to PieChart component

### DIFF
--- a/src/components/charts/pie-chart/pie-chart.js
+++ b/src/components/charts/pie-chart/pie-chart.js
@@ -80,8 +80,8 @@ class PieChart extends PureComponent {
               labelLine={false}
               isAnimationActive={config.animation || false}
               legendType="circle"
-              innerRadius={config.innerRadius || 0}
-              outerRadius={config.outerRadius || null}
+              innerRadius={config.innerRadius}
+              outerRadius={config.outerRadius}
               cx={config.cx}
               cy={config.cy}
             >
@@ -129,7 +129,15 @@ PieChart.propTypes = {
     theme: PropTypes.shape({
       // column: PropTypes.object
       fill: PropTypes.string
-    })
+    }),
+    /** Set inner radius of the chart */
+    innerRadius: PropTypes.number,
+    /** Set outer radius of the chart */
+    outerRadius: PropTypes.number,
+    /** hide values on the chart */
+    hideLabel: PropTypes.bool,
+    /** hide legend component */
+    hideLegend: PropTypes.bool
   }),
   data: PropTypes.arrayOf(
     PropTypes.shape({
@@ -160,7 +168,11 @@ PieChart.defaultProps = {
   config: {},
   data: [],
   customTooltip: null,
-  theme: {}
+  theme: {},
+  innerRadius: 0,
+  outerRadius: null,
+  hideLabel: false,
+  hideLegend: false
 };
 
 export default PieChart;

--- a/src/components/charts/pie-chart/pie-chart.js
+++ b/src/components/charts/pie-chart/pie-chart.js
@@ -17,7 +17,7 @@ import styles from './pie-chart-styles.scss';
 const RADIAN = Math.PI / 180;
 const CustomizedLabel = (
   { cx, cy, midAngle, innerRadius, outerRadius, percent },
-  { labelPositionRatio },
+  { labelPositionRatio, hideLabel },
   theme
 ) =>
   {
@@ -26,18 +26,20 @@ const CustomizedLabel = (
     const x = cx + radius * Math.cos((-midAngle) * RADIAN);
     const y = cy + radius * Math.sin((-midAngle) * RADIAN);
 
-    return (
-      <text
-        x={x}
-        y={y}
-        fill="white"
-        textAnchor={x > cx ? 'start' : 'end'}
-        dominantBaseline="central"
-        className={theme.label}
-      >
-        {`${(percent * 100).toFixed(0)}%`}
-      </text>
-    );
+    return !hideLabel
+      ? (
+        <text
+          x={x}
+          y={y}
+          fill="white"
+          textAnchor={x > cx ? 'start' : 'end'}
+          dominantBaseline="central"
+          className={theme.label}
+        >
+          {`${(percent * 100).toFixed(0)}%`}
+        </text>
+)
+      : null;
   };
 
 CustomizedLabel.propTypes = {
@@ -78,13 +80,17 @@ class PieChart extends PureComponent {
               labelLine={false}
               isAnimationActive={config.animation || false}
               legendType="circle"
+              innerRadius={config.innerRadius || 0}
+              outerRadius={config.outerRadius || null}
+              cx={config.cx}
+              cy={config.cy}
             >
               {data.map(d => <Cell key={d.name} fill={getColor(d, config)} />)}
             </Pie>
           </RechartsPieChart>
         </ResponsiveContainer>
         {
-          Object.keys(config.theme) && (
+          !config.hideLegend && Object.keys(config.theme) && (
           <div
             className={classnames(styles.legend, theme.legend)}
             style={{

--- a/src/components/charts/pie-chart/pie-chart.md
+++ b/src/components/charts/pie-chart/pie-chart.md
@@ -34,7 +34,57 @@ const config = {
     groupD: { label: 'Group D', stroke: 'orange' },
     groupE: { label: 'Group E', stroke: 'maroon' },
     groupF: { label: 'Group F', stroke: 'fuchsia' },
-  }
+  },
+};
+
+<PieChart
+  data={data}
+  width={width}
+  config={config}
+/>
+```
+Example with animated pie chart, inner- and outer- radius with hidden label and legend
+```js
+const width = 400;
+
+const data = [
+  { name: 'groupA', value: 400 },
+  { name: 'groupB', value: 300 },
+  { name: 'groupC', value: 300 },
+  { name: 'groupD', value: 200 },
+  { name: 'groupE', value: 278 },
+  { name: 'groupF', value: 189 }
+];
+
+const config = {
+  tooltip: {
+    groupA: { label: 'Group A' },
+    groupB: { label: 'Group B' },
+    groupC: { label: 'Group C' },
+    groupD: { label: 'Group D' },
+    groupE: { label: 'Group E' },
+    groupF: { label: 'Group F' },
+  },
+  animation: true,
+  axes: {
+    yLeft: {
+      unit: 'MtCO2e',
+      label: '2010'
+    }
+  },
+  theme: { // Color of the slices is in the stroke attribute:
+    // fill: '#f5b335', // Optional -just if monochrome
+    groupA: { label: 'Group A', stroke: 'red' },
+    groupB: { label: 'Group B', stroke: 'blue' },
+    groupC: { label: 'Group C', stroke: 'teal' },
+    groupD: { label: 'Group D', stroke: 'orange' },
+    groupE: { label: 'Group E', stroke: 'maroon' },
+    groupF: { label: 'Group F', stroke: 'fuchsia' },
+  },
+  innerRadius: 50,
+  outerRadius: 80,
+  hideLabel: true,
+  hideLegend: true
 };
 
 <PieChart


### PR DESCRIPTION
This PR adds few new config properties to a pie-chart component:

-  `innerRadius` - set inner radius of the chart,
- `outerRadius` - set outer radius of the chart,
- `hideLabel` - hides values inside the chart
- `hideLegend` - hides legend component

![screenshot from 2019-01-18 16-11-06](https://user-images.githubusercontent.com/15097138/51398532-b8dca880-1b3b-11e9-8df0-487f7b03d9d4.png)
