### PR TITLE
Add bar chart option passing stackId through config

### DIFF
--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -130,12 +130,13 @@ class SimpleBarChart extends PureComponent {
                     />
                   )}
             />
-            {dataKeys.map(dataKey => (
+            {dataKeys.map((dataKey, i) => (
               <Bar
                 key={dataKey}
                 dataKey={dataKey}
                 barSize={barSize}
                 fill={config.theme[dataKey] && config.theme[dataKey].fill}
+                stackId={config.columns.y[i].stackId}
               />
             ))}
           </BarChart>
@@ -146,6 +147,7 @@ class SimpleBarChart extends PureComponent {
 }
 
 SimpleBarChart.propTypes = {
+  /** Add same stackedId attribute to each column object that you want to stack */
   config: PropTypes.shape({ columns: PropTypes.object }),
   data: PropTypes.array,
   showUnit: PropTypes.bool,

--- a/src/components/charts/bar-chart/data-for-stacked-bars.js
+++ b/src/components/charts/bar-chart/data-for-stacked-bars.js
@@ -1,0 +1,40 @@
+export const data = [
+  { x: '0-4', y: 8090282, yTwo: 8090320 },
+  { x: '5-9', y: 8890282, yTwo: 889000 },
+  { x: '10-14', y: 8090282, yTwo: 8890140 },
+  { x: '15-18', y: 8000282, yTwo: 8890100 },
+  { x: '19-24', y: 9090282, yTwo: 8890400 },
+  { x: '25-29', y: 8090282, yTwo: 8890200 }
+];
+
+export const domain = { x: [ 'auto', 'auto' ], y: [ 0, 'auto' ] };
+
+export const config = {
+  axes: {
+    xBottom: {
+      name: 'Age distribution',
+      unit: 'age',
+      format: 'string',
+      label: { dx: 0, dy: 0, className: '' }
+    },
+    yLeft: {
+      name: 'Number of people',
+      unit: 'people',
+      format: 'number',
+      label: { dx: 2, dy: 14, className: '' }
+    }
+  },
+  tooltip: { y: { label: 'people' }, yTwo: { label: 'dogs' } },
+  animation: false,
+  columns: {
+    x: [ { label: 'year', value: 'x' } ],
+    y: [
+      { label: 'y', value: 'y', stackId: 'stackA' },
+      { label: 'yTwo', value: 'yTwo', stackId: 'stackA' }
+    ]
+  },
+  theme: {
+    y: { stroke: '', fill: '#f5b335' },
+    yTwo: { stroke: '', fill: '#00B4D2' }
+  }
+};

--- a/src/components/charts/chart/chart.js
+++ b/src/components/charts/chart/chart.js
@@ -140,6 +140,7 @@ Chart.propTypes = {
         suffix: PropTypes.string
       })
     }),
+    /** In barchart add same stackId attribute to each column object that you want to stack */
     columns: PropTypes.objectOf(
       PropTypes.arrayOf(
         PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -219,3 +219,31 @@ const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
 </React.Fragment>
 ```
 
+
+Example of stacked bar chart
+```js
+const data = require('../bar-chart/data-for-stacked-bars.js');
+const format = require('d3-format').format;
+initialState = {
+  ...data,
+  type: 'bar',
+  loading: false
+};
+const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
+<React.Fragment>
+  <Chart
+    type={state.type}
+    config={state.config}
+    data={state.data}
+    domain={state.domain}
+    height={500}
+    loading={state.loading}
+    getCustomYLabelFormat={getCustomYLabelFormat}
+    barSize={40}
+    barGap={0}
+    showUnit
+    stacked
+  />
+</React.Fragment>
+```
+

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -242,7 +242,6 @@ const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
     barSize={40}
     barGap={0}
     showUnit
-    stacked
   />
 </React.Fragment>
 ```


### PR DESCRIPTION
This PR adds the stacked barchart option
- Pass stackId from every column in config.columns (The columns have to have the same stackId to be stacked ).
- Create example

![image](https://user-images.githubusercontent.com/9701591/51399373-14ac2f00-1b46-11e9-84c1-7133923f5a66.png)
