### PR TITLE
Fix/chart margins

### DIFF
--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -155,7 +155,13 @@ SimpleBarChart.propTypes = {
   onMouseMove: PropTypes.func,
   forceFixedFormatDecimals: PropTypes.number,
   margin: PropTypes.object,
-  chartMargin: PropTypes.object,
+  /** Margin of the chart */
+  chartMargin: PropTypes.shape({
+    top: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number
+  }),
   domain: PropTypes.object,
   customXAxisTick: PropTypes.node,
   customYAxisTick: PropTypes.node,

--- a/src/components/charts/bar-chart/bar-chart.js
+++ b/src/components/charts/bar-chart/bar-chart.js
@@ -39,6 +39,7 @@ class SimpleBarChart extends PureComponent {
       data,
       height,
       margin,
+      chartMargin,
       domain,
       showUnit,
       forceFixedFormatDecimals,
@@ -66,7 +67,6 @@ class SimpleBarChart extends PureComponent {
       ? config.axes.yLeft.label
       : undefined;
 
-    const LineChartMargin = { top: 10, right: 0, left: -10, bottom: 0 };
     const dataKeys = config.columns.y.map(o => o.value);
 
     return (
@@ -75,7 +75,7 @@ class SimpleBarChart extends PureComponent {
           <BarChart
             barGap={barGap}
             data={data}
-            margin={LineChartMargin}
+            margin={chartMargin}
             height={height}
             onMouseMove={this.handleMouseMove}
           >
@@ -155,6 +155,7 @@ SimpleBarChart.propTypes = {
   onMouseMove: PropTypes.func,
   forceFixedFormatDecimals: PropTypes.number,
   margin: PropTypes.object,
+  chartMargin: PropTypes.object,
   domain: PropTypes.object,
   customXAxisTick: PropTypes.node,
   customYAxisTick: PropTypes.node,
@@ -171,6 +172,7 @@ SimpleBarChart.defaultProps = {
   onMouseMove: () => {
   },
   margin: { top: 0, right: 10, left: 10, bottom: 0 },
+  chartMargin: { top: 10, right: 0, left: -10, bottom: 0 },
   domain: null,
   forceFixedFormatDecimals: null,
   config: {},

--- a/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-styles.scss
+++ b/src/components/charts/bar-chart/bar-tooltip-chart/bar-tooltip-chart-styles.scss
@@ -20,7 +20,7 @@
     color: $theme-color;
   }
 
-  &:last-child {
+  &:not(:first-child) {
     color: #77818c;
   }
 }

--- a/src/components/charts/chart-composed/chart-composed.js
+++ b/src/components/charts/chart-composed/chart-composed.js
@@ -184,7 +184,13 @@ ChartComposed.propTypes = {
   onMouseMove: PropTypes.func,
   forceFixedFormatDecimals: PropTypes.number,
   margin: PropTypes.object,
-  chartMargin: PropTypes.object,
+  /** Margin of the chart */
+  chartMargin: PropTypes.shape({
+    top: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number
+  }),
   domain: PropTypes.object,
   theme: PropTypes.shape({ legend: PropTypes.string }),
   children: PropTypes.node.isRequired,

--- a/src/components/charts/chart-composed/chart-composed.js
+++ b/src/components/charts/chart-composed/chart-composed.js
@@ -48,6 +48,7 @@ class ChartComposed extends PureComponent {
       dataSelected,
       height,
       margin,
+      chartMargin,
       domain,
       showUnit,
       forceFixedFormatDecimals,
@@ -68,7 +69,6 @@ class ChartComposed extends PureComponent {
       has(config, 'axes.yLeft.suffix') &&
       config.axes.yLeft.suffix ||
       null;
-    const LineChartMargin = { top: 10, right: 0, left: -10, bottom: 0 };
     const hasDataOptions = !loading && dataOptions;
 
     return (
@@ -76,7 +76,7 @@ class ChartComposed extends PureComponent {
         <ResponsiveContainer height={height} margin={margin}>
           <ComposedChart
             data={data}
-            margin={LineChartMargin}
+            margin={chartMargin}
             onMouseMove={this.handleMouseMove}
           >
             {areaAsBackgroundForCartesianGrid}
@@ -184,6 +184,7 @@ ChartComposed.propTypes = {
   onMouseMove: PropTypes.func,
   forceFixedFormatDecimals: PropTypes.number,
   margin: PropTypes.object,
+  chartMargin: PropTypes.object,
   domain: PropTypes.object,
   theme: PropTypes.shape({ legend: PropTypes.string }),
   children: PropTypes.node.isRequired,
@@ -214,6 +215,7 @@ ChartComposed.defaultProps = {
   hideRemoveOptions: false,
   dataSelected: [],
   margin: { top: 0, right: 10, left: 10, bottom: 0 },
+  chartMargin: { top: 10, right: 0, left: -10, bottom: 0 },
   domain: null,
   forceFixedFormatDecimals: null,
   theme: {},

--- a/src/components/charts/chart/chart.md
+++ b/src/components/charts/chart/chart.md
@@ -242,6 +242,7 @@ const getCustomYLabelFormat = value => `${format('.2s')(`${value / 10000}`)}`;
     barSize={40}
     barGap={0}
     showUnit
+    chartMargin={{ right: 20 }}
   />
 </React.Fragment>
 ```

--- a/src/components/charts/line/line.js
+++ b/src/components/charts/line/line.js
@@ -74,7 +74,7 @@ class ChartLine extends PureComponent {
       customTooltip,
       getCustomYLabelFormat,
       projectedData,
-      lineChartMargin
+      chartMargin
     } = this.props;
     const { activePoint, tooltipVisibility } = this.state;
     const unit = showUnit && has(config, 'axes.yLeft.unit')
@@ -92,7 +92,7 @@ class ChartLine extends PureComponent {
       <ResponsiveContainer height={height} margin={margin}>
         <LineChart
           data={data}
-          margin={lineChartMargin}
+          margin={chartMargin}
           onMouseMove={this.handleMouseMove}
         >
           <XAxis
@@ -209,7 +209,7 @@ ChartLine.propTypes = {
   onMouseMove: PropTypes.func,
   forceFixedFormatDecimals: PropTypes.number,
   margin: PropTypes.object,
-  lineChartMargin: PropTypes.object,
+  chartMargin: PropTypes.object,
   domain: PropTypes.object,
   lineType: PropTypes.string,
   customYAxisTick: PropTypes.node,
@@ -226,7 +226,7 @@ ChartLine.defaultProps = {
   onMouseMove: () => {
   },
   margin: { top: 0, right: 10, left: 10, bottom: 0 },
-  lineChartMargin: { top: 45, right: 0, left: -10, bottom: 0 },
+  chartMargin: { top: 45, right: 0, left: -10, bottom: 0 },
   domain: null,
   forceFixedFormatDecimals: null,
   lineType: 'monotone',

--- a/src/components/charts/line/line.js
+++ b/src/components/charts/line/line.js
@@ -209,7 +209,13 @@ ChartLine.propTypes = {
   onMouseMove: PropTypes.func,
   forceFixedFormatDecimals: PropTypes.number,
   margin: PropTypes.object,
-  chartMargin: PropTypes.object,
+  /** Margin of the chart */
+  chartMargin: PropTypes.shape({
+    top: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number
+  }),
   domain: PropTypes.object,
   lineType: PropTypes.string,
   customYAxisTick: PropTypes.node,

--- a/src/components/charts/percentage/percentage.js
+++ b/src/components/charts/percentage/percentage.js
@@ -68,7 +68,8 @@ class ChartPercentage extends PureComponent {
       customXAxisTick,
       customYAxisTick,
       customTooltip,
-      showUnit
+      showUnit,
+      chartMargin
     } = this.props;
     const percentageState = { data, config };
     const percentageData = getData(percentageState);
@@ -91,7 +92,7 @@ class ChartPercentage extends PureComponent {
       <ResponsiveContainer height={height}>
         <ComposedChart
           data={percentageData}
-          margin={{ top: 45, right: 20, left: -10, bottom: 0 }}
+          margin={chartMargin}
           onMouseMove={this.handleMouseMove}
           stackOffset="sign"
         >
@@ -175,6 +176,7 @@ ChartPercentage.propTypes = {
     // % accepted
     PropTypes.string
   ]),
+  chartMargin: PropTypes.object,
   onMouseMove: PropTypes.func,
   stepped: PropTypes.bool,
   customYAxisTick: PropTypes.node,
@@ -188,6 +190,7 @@ ChartPercentage.defaultProps = {
   data: [],
   onMouseMove: () => {
   },
+  chartMargin: { top: 45, right: 20, left: -10, bottom: 0 },
   stepped: false,
   customYAxisTick: null,
   customXAxisTick: null,

--- a/src/components/charts/percentage/percentage.js
+++ b/src/components/charts/percentage/percentage.js
@@ -176,7 +176,13 @@ ChartPercentage.propTypes = {
     // % accepted
     PropTypes.string
   ]),
-  chartMargin: PropTypes.object,
+  /** Margin of the chart */
+  chartMargin: PropTypes.shape({
+    top: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number
+  }),
   onMouseMove: PropTypes.func,
   stepped: PropTypes.bool,
   customYAxisTick: PropTypes.node,

--- a/src/components/charts/stacked-area/stacked-area.js
+++ b/src/components/charts/stacked-area/stacked-area.js
@@ -131,7 +131,8 @@ class ChartStackedArea extends PureComponent {
       customYAxisTick,
       customTooltip,
       getCustomYLabelFormat,
-      showUnit
+      showUnit,
+      chartMargin
     } = this.props;
 
     const stackedAreaState = { projectedData, data, config };
@@ -161,7 +162,7 @@ class ChartStackedArea extends PureComponent {
       <ResponsiveContainer height={height}>
         <ComposedChart
           data={dataWithTotal}
-          margin={{ top: 45, right: 20, left: -10, bottom: 0 }}
+          margin={chartMargin}
           onMouseMove={this.handleMouseMove}
           onMouseLeave={() => this.setLastPoint(true)}
           onMouseEnter={() => this.setLastPoint(false)}
@@ -297,6 +298,7 @@ ChartStackedArea.propTypes = {
     PropTypes.string
   ]),
   onMouseMove: PropTypes.func,
+  chartMargin: PropTypes.object,
   includeTotalLine: PropTypes.bool,
   stepped: PropTypes.bool,
   customYAxisTick: PropTypes.node,
@@ -312,6 +314,7 @@ ChartStackedArea.defaultProps = {
   projectedData: [],
   onMouseMove: () => {
   },
+  chartMargin: { top: 45, right: 20, left: -10, bottom: 0 },
   includeTotalLine: true,
   stepped: false,
   customYAxisTick: null,

--- a/src/components/charts/stacked-area/stacked-area.js
+++ b/src/components/charts/stacked-area/stacked-area.js
@@ -298,7 +298,13 @@ ChartStackedArea.propTypes = {
     PropTypes.string
   ]),
   onMouseMove: PropTypes.func,
-  chartMargin: PropTypes.object,
+  /** Margin of the chart */
+  chartMargin: PropTypes.shape({
+    top: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number
+  }),
   includeTotalLine: PropTypes.bool,
   stepped: PropTypes.bool,
   customYAxisTick: PropTypes.node,


### PR DESCRIPTION
This PR updates the charts adding a chartMargin prop that really acts as a margin as the margin prop in the ResponsiveContainer was not working in the same way. 
There was a linechartMargin prop in the line chart which is updated with this one. I think we are not using it but anyway I will check the current projects for it.

Also, it fixes the color of the tooltip text for the barchart:
Before:
![image](https://user-images.githubusercontent.com/9701591/51627179-a13d5f80-1f41-11e9-9999-ebaf02cdd4c3.png)

After:
![image](https://user-images.githubusercontent.com/9701591/51627108-70f5c100-1f41-11e9-9598-eaa79a5e5ce4.png)
