### PR TITLE
Feature/modal header with tabs component

### DIFF
--- a/src/components/modal/modal-header.js
+++ b/src/components/modal/modal-header.js
@@ -2,19 +2,38 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
+import Tab from 'components/tab';
+
 import styles from './modal-styles.scss';
 
 class ModalHeader extends PureComponent {
   render() {
-    const { title, theme, children } = this.props;
+    const {
+      title,
+      tabTitles,
+      tabSelectedIndex,
+      handleTabIndexChange,
+      theme,
+      children
+    } = this.props;
+
     return (
       <div className={cx(styles.header, theme.header)}>
         {
-          title &&
+          title && (
+          <h2 className={cx(styles.headerTitle, theme.headerTitle)}>
+            {title}
+          </h2>
+            )
+        }
+        {
+          tabTitles &&
             (
-              <h2 className={cx(styles.headerTitle, theme.headerTitle)}>
-                {title}
-              </h2>
+              <Tab
+                options={tabTitles}
+                selectedIndex={tabSelectedIndex}
+                handleTabIndexChange={handleTabIndexChange}
+              />
             )
         }
         {children}
@@ -25,6 +44,9 @@ class ModalHeader extends PureComponent {
 
 ModalHeader.propTypes = {
   title: PropTypes.string,
+  tabTitles: PropTypes.arrayOf(PropTypes.string),
+  tabSelectedIndex: PropTypes.number,
+  handleTabIndexChange: PropTypes.func,
   theme: PropTypes.shape({
     header: PropTypes.string,
     headerTitle: PropTypes.string
@@ -32,6 +54,14 @@ ModalHeader.propTypes = {
   children: PropTypes.node
 };
 
-ModalHeader.defaultProps = { title: 'Modal title', theme: {}, children: null };
+ModalHeader.defaultProps = {
+  title: null,
+  tabTitles: null,
+  tabSelectedIndex: 0,
+  handleTabIndexChange: () => {
+  },
+  theme: {},
+  children: null
+};
 
 export default ModalHeader;

--- a/src/components/modal/modal.md
+++ b/src/components/modal/modal.md
@@ -1,4 +1,3 @@
-
 ```js
 initialState = { open: false };
 const toggleModalOpen = (slug) => {
@@ -10,7 +9,7 @@ const ModalHeader = require('./modal-header.js').default;
 const Button = require('../button').default;
 <React.Fragment>
   <Button onClick={toggleModalOpen} >
-    Open it
+    Open modal with simple header
   </Button>
   <Modal
     isOpen={state.open}
@@ -22,3 +21,44 @@ const Button = require('../button').default;
 </React.Fragment>
 ```
 
+```js
+initialState = { open: false, tabSelectedIndex: 0 };
+const tabTitles = ['Tab 1', 'Tab 2'];
+const toggleModalOpen = (slug) => {
+  setState((state) => {
+    return { open: !state.open }
+  });
+};
+const handleTabIndexChange = (index) => {
+  setState({ tabSelectedIndex: index });
+};
+const getModalContent = (tabIndex) => {
+  return (
+    <h2>
+      {`Modal content for ${tabTitles[tabIndex]}`}
+    </h2>
+  );
+};
+
+const ModalHeader = require('./modal-header.js').default;
+const Button = require('../button').default;
+<React.Fragment>
+  <Button onClick={toggleModalOpen} >
+    Open modal with tabs in the header
+  </Button>
+  <Modal
+    isOpen={state.open}
+    onRequestClose={toggleModalOpen}
+    header={
+      <ModalHeader
+        title="My modal title"
+        tabTitles={tabTitles}
+        tabSelectedIndex={state.tabSelectedIndex}
+        handleTabIndexChange={handleTabIndexChange}
+      />
+    }
+  >
+    {getModalContent(state.tabSelectedIndex)}
+  </Modal>
+</React.Fragment>
+```

--- a/src/components/tab/tab-component.jsx
+++ b/src/components/tab/tab-component.jsx
@@ -1,0 +1,47 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+import styles from './tab-styles.scss';
+
+class Tab extends PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
+  render() {
+    const {
+      options,
+      selectedIndex,
+      handleTabIndexChange,
+      classNames
+    } = this.props;
+    return (
+      <div className={cx(styles.tab, classNames)}>
+        {options.map((option, i) => (
+          <button
+            key={option}
+            className={cx([
+              styles.link,
+              { [styles.linkActive]: selectedIndex === i }
+            ])}
+            onClick={() => handleTabIndexChange(i)}
+            role="menuitem"
+            type="button"
+            tabIndex={-1}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+    );
+  }
+}
+
+Tab.propTypes = {
+  options: PropTypes.array.isRequired,
+  selectedIndex: PropTypes.number.isRequired,
+  handleTabIndexChange: PropTypes.func.isRequired,
+  classNames: PropTypes.string
+};
+
+Tab.defaultProps = { classNames: '' };
+
+export default Tab;

--- a/src/components/tab/tab-styles.scss
+++ b/src/components/tab/tab-styles.scss
@@ -1,0 +1,31 @@
+@import '~styles/settings.scss';
+
+.tab {
+  display: flex;
+  align-items: center;
+  margin-top: 15px;
+}
+
+.link {
+  font-family: $font-family-1;
+  font-size: $font-size;
+  border: 0;
+  background-color: transparent;
+  color: $theme-color;
+  margin-right: 30px;
+  padding-bottom: 15px;
+  text-decoration: none;
+  position: relative;
+  cursor: pointer;
+
+  &Active::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: $theme-secondary;
+    width: 100%;
+    height: 4px;
+  }
+}

--- a/src/components/tab/tab.js
+++ b/src/components/tab/tab.js
@@ -1,0 +1,3 @@
+import Component from './tab-component';
+
+export default Component;

--- a/src/components/tab/tab.md
+++ b/src/components/tab/tab.md
@@ -1,0 +1,21 @@
+``` js
+
+const tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
+
+initialState = {
+  selectedIndex: 0
+};
+
+const handleTabIndexChange = (index) => setState({ selectedIndex: index });
+
+<React.Fragment>
+  <Tab
+    options={tabs}
+    selectedIndex={state.selectedIndex}
+    handleTabIndexChange={handleTabIndexChange}
+  />
+  <div>
+    <h3>Selected tab: {tabs[state.selectedIndex]}</h3>
+  </div>
+</React.Fragment>
+```

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ export { default as Section } from './components/section';
 export { default as Stories } from './components/stories';
 export { default as Switch } from './components/switch';
 export { default as SunburstChart } from './components/charts/sunburst-chart';
+export { default as Tab } from './components/tab';
 export { default as Table } from './components/table';
 export { default as Tag } from './components/tag';
 export { default as TooltipChart } from './components/charts/tooltip-chart';


### PR DESCRIPTION
Adding `Tab`s into `ModalHeader` component.

New component: `Tab`

![image](https://user-images.githubusercontent.com/1286444/51968913-5fe20e00-2473-11e9-8793-7796d02e1204.png)

I was thinking if it was better to add extra props to the existing header component (as it is done here) or create a new specialized component `ModalHeaderWithTabs`. What are your thoughts?