### PR TITLE
Fix icon size and add themes for further configuration

### DIFF
--- a/src/components/dropdown/dropdown-styles.scss
+++ b/src/components/dropdown/dropdown-styles.scss
@@ -35,7 +35,7 @@
 }
 
 .iconOption {
-  padding-left: 10px;
+  margin-left: 10px;
   width: 20px;
   height: 30px;
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -138,7 +138,9 @@ Dropdown.propTypes = {
     dot: PropTypes.string,
     dropdow: PropTypes.string,
     select: PropTypes.string,
-    icon: PropTypes.string
+    icon: PropTypes.string,
+    iconValue: PropTypes.string,
+    iconOption: PropTypes.string
   }),
   icons: PropTypes.shape(iconsShape),
   value: PropTypes.shape(valueShape),

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -85,13 +85,13 @@ class Dropdown extends PureComponent {
                 renderOption={item => (
                   <Icon
                     icon={icons[item.label]}
-                    theme={{ icon: styles.iconOption }}
+                    theme={{ icon: cx(styles.iconOption, theme.iconOption) }}
                   />
                 )}
                 renderValue={item => (
                   <Icon
                     icon={icons[item.label]}
-                    theme={{ icon: styles.iconValue }}
+                    theme={{ icon: cx(styles.iconValue, theme.iconValue) }}
                   />
                 )}
                 hideResetButton={hideResetButton}


### PR DESCRIPTION
This is a little fix for the icons dropdown. In the playground won't be changes but we had a problem using padding instead of margin in CW:

Before: 
![image](https://user-images.githubusercontent.com/9701591/52268437-d54e5280-293b-11e9-8e40-ddfa40f883d1.png)

After:
![image](https://user-images.githubusercontent.com/9701591/52268664-67565b00-293c-11e9-9433-4c3b03734612.png)
