### PR TITLE
webpack dev to test components locally linked

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,34 @@ and will be ready to use them!
 
 Install using yarn install. Package-lock.json won't be created as we want to avoid conflicts
 
+## How to link component locally
+
+1. Register cw-components as linked package. Run `yarn link`. Have to be done just once.
+2. Run `yarn dev` to run webpack with development config.
+3. On app repo. `yarn link cw-components`.
+
+To remove this local linked package from the application. Run following on the app repo:
+
+1. Unlink package `yarn unlink cw-components`.
+2. Remove node modules `rm -rf node_modules`.
+3. Reinstall packages `yarn` to bring back previous version of cw-components.
+
+
+Make sure that React, react-dom or maybe other libraries are not loaded twice when linking this package locally.
+
+In the app webpack configuration, resolve packages to always use app's node_modules version
+
+```
+  resolve: {
+    alias: {
+      react: path.resolve('./node_modules/react'),
+      'react-dom': path.resolve('./node_modules/react-dom')
+    }
+  }
+```
+
+You can also add [duplication checker plugin](https://github.com/darrenscerri/duplicate-package-checker-webpack-plugin) to know about other duplicated libraries.
+
 ## How to release
 
 We are using the [release](https://github.com/zeit/release) package to run automatically this process

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "styleguidist server",
     "build": "styleguidist build",
     "compile": "webpack",
+    "dev": "webpack --config webpack-dev.config.js --watch",
     "deploy": "yarn run build && gh-pages -d styleguide"
   },
   "lint-staged": {

--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const glob = require('glob');
+const DirectoryNamedWebpackPlugin = require('directory-named-webpack-plugin');
+
+const config = {
+  entry: './src/index.js',
+  mode: 'development',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+    libraryTarget: 'umd',
+    umdNamedDefine: true
+  },
+  node: { fs: 'empty', net: 'empty' },
+  module: {
+    rules: [
+      { test: /\.jsx?$/, loader: 'babel-loader', exclude: /node_modules/ },
+      { test: /\.(jpg|jpeg|png|gif)$/, use: 'url-loader' },
+      { test: /\.svg$/, use: [ { loader: 'svg-sprite-loader' } ] },
+      {
+        test: /\.scss$/,
+        use: [
+          'style-loader',
+          'css-loader?modules&importLoaders=1&localIdentName=cw__[name]_[local]',
+          'resolve-url-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              includePaths: [ './node_modules', './src/styles' ]
+                .map(d => path.join(__dirname, d))
+                .map(g => glob.sync(g))
+                .reduce((a, c) => a.concat(c), [])
+            }
+          }
+        ]
+      }
+    ]
+  },
+  externals: [ 'react', 'react-dom', 'classnames', 'lodash', 'prop-types' ],
+  resolve: {
+    extensions: [ '.js', '.jsx', '.json' ],
+    symlinks: false,
+    plugins: [ new DirectoryNamedWebpackPlugin(true) ],
+    alias: {
+      components: path.resolve(__dirname, 'src/components/'),
+      styles: path.resolve(__dirname, 'src/styles/'),
+      utils: path.resolve(__dirname, 'src/utils/')
+    }
+  },
+  plugins: []
+};
+
+module.exports = config;


### PR DESCRIPTION
Adding development webpack config to be able to test components locally using `yarn link`.

Instruction in the updated readme.

Inspiration taken from here https://medium.com/@penx/managing-dependencies-in-a-node-package-so-that-they-are-compatible-with-npm-link-61befa5aaca7

Could be tested with this Indonesia PR: https://github.com/ClimateWatch-Vizzuality/indonesia-platform/pull/62