### PR TITLE
when showing targets, eliminate gaps in years between them and data point values

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     }
   },
   "dependencies": {
+    "@d3fc/d3fc-discontinuous-scale": "^3.0.7",
     "@latticejs/recharts-sunburst": "^1.0.1-beta.0",
     "d3-format": "1.3.0",
     "d3-hierarchy": "^1.1.8",

--- a/src/components/charts/line/line.js
+++ b/src/components/charts/line/line.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import has from 'lodash/has';
+import get from 'lodash/get';
 import {
   LineChart,
   Line,
@@ -22,7 +22,8 @@ import { CustomXAxisTick, CustomYAxisTick } from './axis-ticks';
 import {
   getDataMaxMin,
   getDataWithTotal,
-  getDomain
+  getDomain,
+  getDiscontinousScale
 } from '../selectors/chart-selectors';
 
 class ChartLine extends PureComponent {
@@ -76,16 +77,13 @@ class ChartLine extends PureComponent {
       projectedData
     } = this.props;
     const { activePoint, tooltipVisibility } = this.state;
-    const unit = showUnit && has(config, 'axes.yLeft.unit')
-      ? config.axes.yLeft.unit
-      : null;
-    const suffix = has(config, 'axes.yLeft.suffix')
-      ? config.axes.yLeft.suffix
-      : null;
+    const unit = showUnit && get(config, 'axes.yLeft.unit', null);
+    const suffix = get(config, 'axes.yLeft.suffix', null);
     const lineState = { projectedData, data, config };
     const dataMaxMin = getDataMaxMin(lineState);
     const domain = projectedData ? getDomain(lineState) : customDomain;
     const lastData = getMaxValue(getDataWithTotal(lineState));
+    const xAxisScale = getDiscontinousScale(lineState) || 'time';
 
     return (
       <ResponsiveContainer height={height}>
@@ -96,7 +94,7 @@ class ChartLine extends PureComponent {
         >
           <XAxis
             dataKey="x"
-            scale="time"
+            scale={xAxisScale}
             type="number"
             tick={customXAxisTick || <CustomXAxisTick />}
             padding={{ left: 15, right: 20 }}

--- a/src/components/charts/stacked-area/stacked-area.js
+++ b/src/components/charts/stacked-area/stacked-area.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 import { isMicrosoftBrowser, getCustomTicks, getMaxValue } from 'utils';
 import isUndefined from 'lodash/isUndefined';
-import has from 'lodash/has';
+import get from 'lodash/get';
 import { format } from 'd3-format';
 import {
   ComposedChart,
@@ -25,7 +25,8 @@ import ProjectedData from '../projected-data';
 import {
   getDataWithTotal,
   getDomain,
-  getDataMaxMin
+  getDataMaxMin,
+  getDiscontinousScale
 } from '../selectors/chart-selectors';
 import { CustomXAxisTick, CustomYAxisTick } from './axis-ticks';
 
@@ -151,12 +152,10 @@ class ChartStackedArea extends PureComponent {
       dataWithTotal.concat(projectedData),
       5
     );
-    const suffix = has(config, 'axes.yLeft.suffix')
-      ? config.axes.yLeft.suffix
-      : null;
-    const unit = showUnit && has(config, 'axes.yLeft.unit')
-      ? config.axes.yLeft.unit
-      : null;
+    const suffix = get(config, 'axes.yLeft.suffix', null);
+    const unit = showUnit && get(config, 'axes.yLeft.unit', null);
+    const anyProjectedData = projectedData && projectedData.length;
+    const xAxisScale = getDiscontinousScale(stackedAreaState) || 'auto';
 
     return (
       <ResponsiveContainer height={height}>
@@ -170,6 +169,7 @@ class ChartStackedArea extends PureComponent {
         >
           <XAxis
             domain={domain.x}
+            scale={xAxisScale}
             type="number"
             dataKey="x"
             padding={{ left: 30, right: 40 }}
@@ -267,13 +267,11 @@ class ChartStackedArea extends PureComponent {
           }
           {showLastPoint && renderLastPoint(lastData)}
           {
-            projectedData &&
-              projectedData.length &&
+            anyProjectedData &&
               DividerLine({ x: lastData.x, labels: config.dividerLine })
           }
           {
-            projectedData &&
-              projectedData.length &&
+            anyProjectedData &&
               ProjectedData({
                 data: projectedData,
                 dataMaxMin,

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,20 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@d3fc/d3fc-discontinuous-scale@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@d3fc/d3fc-discontinuous-scale/-/d3fc-discontinuous-scale-3.0.7.tgz#4b56876d0a9dd6ad7bfdd07849a0b4e9fa255074"
+  integrity sha512-2/M+WqzN9wkmS5ElmNZKeBmPlcsMY4lOw+AEFxcFZiEc2bGv/7GusiU/9XYsvtkyfEbl9cihi+o34y09Hbij3Q==
+  dependencies:
+    "@d3fc/d3fc-rebind" "^5.0.6"
+    d3-scale "^1.0.0"
+    d3-time "^1.0.0"
+
+"@d3fc/d3fc-rebind@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@d3fc/d3fc-rebind/-/d3fc-rebind-5.0.6.tgz#2c3abacb24827f98592cb2eae9913a76cb2391c8"
+  integrity sha512-ZT6wRZ7HkDav71prw6BUD3ER7Y40xuAhqGbdVeXaEy6OFzOipE8NgrVWYh7HHb30GFgO+ygpnAeLtuxQmugIwQ==
+
 "@latticejs/recharts-sunburst@^1.0.1-beta.0":
   version "1.0.1-beta.0"
   resolved "https://registry.yarnpkg.com/@latticejs/recharts-sunburst/-/recharts-sunburst-1.0.1-beta.0.tgz#560a7152bc15cea279e7347dac3c778553b3adbd"
@@ -2653,6 +2667,19 @@ d3-scale@1.0.6:
     d3-time "1"
     d3-time-format "2"
 
+d3-scale@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.7.tgz#fa90324b3ea8a776422bd0472afab0b252a0945d"
+  integrity sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-color "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
 d3-shape@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
@@ -2674,6 +2701,11 @@ d3-time-format@2:
 d3-time@1:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.8.tgz#dbd2d6007bf416fe67a76d17947b784bffea1e84"
+
+d3-time@^1.0.0:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.11.tgz#1d831a3e25cd189eb256c17770a666368762bbce"
+  integrity sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Could be tested on Indonesia platform.

Both line and area charts for National or Province GHG Emissions.

Before

![image](https://user-images.githubusercontent.com/1286444/52640914-f41e8d00-2ed7-11e9-95eb-baa00c582aae.png)

After

![image](https://user-images.githubusercontent.com/1286444/52640961-16180f80-2ed8-11e9-9694-e03019290932.png)
