### PR TITLE
Feature/table auto horizontal scroll

### DIFF
--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -91,7 +91,6 @@ p {
   .ReactVirtualized__Grid,
   .ReactVirtualized__Table__Grid {
     border-top: solid 1px $theme-color-light;
-    overflow: inherit !important;
 
     &:focus {
       outline: none;

--- a/src/components/table/table-styles.scss
+++ b/src/components/table/table-styles.scss
@@ -91,6 +91,7 @@ p {
   .ReactVirtualized__Grid,
   .ReactVirtualized__Table__Grid {
     border-top: solid 1px $theme-color-light;
+    overflow: inherit !important;
 
     &:focus {
       outline: none;

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -50,15 +50,7 @@ class Table extends PureComponent {
   }
 
   componentDidMount() {
-    const tableWrapper = window &&
-      window.document.getElementById('tableWrapper');
-    this.tableWrapperWidth = tableWrapper && tableWrapper.offsetWidth;
-  }
-
-  componentDidUpdate() {
-    const tableWrapper = window &&
-      window.document.getElementById('tableWrapper');
-    this.tableWrapperWidth = tableWrapper && tableWrapper.offsetWidth;
+    this.tableWrapperWidth = this.tableWrapper && this.tableWrapper.offsetWidth;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -81,6 +73,7 @@ class Table extends PureComponent {
   };
 
   getFullWidth = (data, columns, width) => {
+    const { setColumnWidth } = this.props;
     const columnsLenght = columns.length;
     if (columnsLenght === 1) return width;
     const totalWidth = columns.reduce(
@@ -88,8 +81,12 @@ class Table extends PureComponent {
         acc + this.getColumnLength(data, column.label) + this.rowColumnMargin,
       this.rowColumnMargin + 10
     );
-    this.setState({ shouldOverflow: width < this.tableWrapperWidth });
-    return totalWidth < width ? width : totalWidth;
+    this.tableWrapperWidth = this.tableWrapper && this.tableWrapper.offsetWidth;
+    const realWidth = setColumnWidth
+      ? (setColumnWidth() + this.rowColumnMargin + 10) * columnsLenght
+      : totalWidth;
+    this.setState({ shouldOverflow: realWidth > this.tableWrapperWidth });
+    return realWidth < width ? width : realWidth;
   };
 
   getDataSorted = (data, sortBy, sortDirection) => {
@@ -295,7 +292,9 @@ class Table extends PureComponent {
             )
         }
         <div
-          id="tableWrapper"
+          ref={table => {
+            this.tableWrapper = table;
+          }}
           className={cx(styles.tableWrapper, {
             [styles.horizontalScroll]: shouldOverflow
           })}

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -49,6 +49,12 @@ class Table extends PureComponent {
     );
   }
 
+  componentDidMount() {
+    const tableWrapper = window &&
+      window.document.getElementById('tableWrapper');
+    this.tableWrapperWidth = tableWrapper && tableWrapper.offsetWidth;
+  }
+
   componentDidUpdate() {
     const tableWrapper = window &&
       window.document.getElementById('tableWrapper');

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -30,7 +30,8 @@ class Table extends PureComponent {
       sortBy: sortBy || get(allColumns, '[0]'),
       sortDirection: SortDirection.ASC,
       activeColumns: columns.map(d => ({ label: d, value: d })),
-      columnsOptions: allColumns.map(d => ({ label: d, value: d }))
+      columnsOptions: allColumns.map(d => ({ label: d, value: d })),
+      shouldOverflow: false
     };
     this.standardColumnWidth = 180;
     this.minColumnWidth = 80;
@@ -46,6 +47,12 @@ class Table extends PureComponent {
       styles.rowcolumnmargin.replace('px', ''),
       10
     );
+  }
+
+  componentDidUpdate() {
+    const tableWrapper = window &&
+      window.document.getElementById('tableWrapper');
+    this.tableWrapperWidth = tableWrapper && tableWrapper.offsetWidth;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -75,6 +82,7 @@ class Table extends PureComponent {
         acc + this.getColumnLength(data, column.label) + this.rowColumnMargin,
       this.rowColumnMargin + 10
     );
+    this.setState({ shouldOverflow: width < this.tableWrapperWidth });
     return totalWidth < width ? width : totalWidth;
   };
 
@@ -191,7 +199,8 @@ class Table extends PureComponent {
       sortDirection,
       activeColumns,
       columnsOptions,
-      optionsOpen
+      optionsOpen,
+      shouldOverflow
     } = this.state;
     const {
       data: propsData,
@@ -200,7 +209,6 @@ class Table extends PureComponent {
       headerHeight,
       setRowsHeight,
       ellipsisColumns,
-      horizontalScroll,
       dynamicRowsHeight,
       hiddenColumnHeaderLabels
     } = this.props;
@@ -281,8 +289,9 @@ class Table extends PureComponent {
             )
         }
         <div
+          id="tableWrapper"
           className={cx(styles.tableWrapper, {
-            [styles.horizontalScroll]: horizontalScroll
+            [styles.horizontalScroll]: shouldOverflow
           })}
         >
           <AutoSizer disableHeight>
@@ -370,8 +379,6 @@ Table.propTypes = {
   /** Trim line to include ... */
   // eslint-disable-next-line react/forbid-prop-types
   ellipsisColumns: PropTypes.array,
-  /** Boolean to allow scroll in the horizontal direction */
-  horizontalScroll: PropTypes.bool.isRequired,
   /** Array to order the column headers */
   // eslint-disable-next-line react/forbid-prop-types
   firstColumnHeaders: PropTypes.array,


### PR DESCRIPTION
This PR updates table component to allow horizontal scroll depending on table `width`to address this task:
https://www.pivotaltracker.com/story/show/163790391

The functionality could be tested on Indonesia platform via `yarn link cw-components`:
`http://localhost:3000/en/national-context/climate-funding`
`http://localhost:3000/en/regions/ID.AC/climate-sectoral-plan`

`horizontalScroll` boolean prop has been substituted by an internal calculation

![kapture 2019-02-14 at 13 35 33](https://user-images.githubusercontent.com/6906348/52788719-17754380-3062-11e9-8316-c0a0075ab870.gif)


