### PR TITLE
Avoiding global opacity for multiselect resizable input

### DIFF
--- a/src/components/multiselect/multiselect-styles.scss
+++ b/src/components/multiselect/multiselect-styles.scss
@@ -77,12 +77,8 @@
   }
 }
 
-:global .multi-select .react-selectize-search-field-and-selected-values .resizable-input {
+.unsearchable :global .react-selectize-search-field-and-selected-values .resizable-input {
   opacity: 0;
-}
-
-.searchable :global .react-selectize-search-field-and-selected-values .resizable-input {
-  opacity: 1;
 }
 
 .selected {

--- a/src/components/multiselect/multiselect.js
+++ b/src/components/multiselect/multiselect.js
@@ -128,15 +128,14 @@ class Multiselect extends Component {
             styles.multiSelect,
             children ? styles.hasChildren : '',
             { [styles.mirrorX]: mirrorX },
-            { [styles.searchable]: !icon }
+            { [styles.unsearchable]: icon }
           )}
         >
           {
-            !icon &&
-              (
-                <div className={cx(styles.values, 'values')}>
-                  {this.getSelectorValue()}
-                </div>
+            !icon && (
+            <div className={cx(styles.values, 'values')}>
+              {this.getSelectorValue()}
+            </div>
               )
           }
           {loading && <Loading className={styles.loader} mini />}


### PR DESCRIPTION
This global `opacity: 0` is sometimes overriding styles from CW flagship MultiSelect component. That causes that search input is not visible even if it's working. I'm going to do the same change to climate watch local MultiSelect component as it is still used in some places.