### PR TITLE
Set default width when setColumnWidth value is null

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -176,9 +176,8 @@ class Table extends PureComponent {
 
   columnWidthProps = column => {
     const { setColumnWidth, data } = this.props;
-    const length = setColumnWidth
-      ? setColumnWidth(column)
-      : this.getColumnLength(data, column);
+    const customColumnWidth = setColumnWidth && setColumnWidth(column);
+    const length = customColumnWidth || this.getColumnLength(data, column);
     return { width: length, minWidth: length, maxWidth: length };
   };
 

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -4,6 +4,11 @@ const data = require('./data.json');
 const defaultColumns = ["name", "definition", "very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_header_label", "unit", "composite_name"];
 const ellipsisColumns = ["composite_name"];
 const firstColumnHeaders = ["composite_name", "name"];
+const narrowColumns = ['definition']
+const setColumnWidth = column => {
+  if (narrowColumns.includes(column)) return 100;
+  return null
+}
 
 <Table
   data={data}
@@ -17,5 +22,6 @@ const firstColumnHeaders = ["composite_name", "name"];
   dynamicRowsHeight={true}
   titleLinks={data.map(c => [{columnName: "link", url: "self", label: "View more"}])}
   hiddenColumnHeaderLabels={['link']}
+  setColumnWidth={setColumnWidth}
 />
 ```


### PR DESCRIPTION
This Pr allows to set the width of the desired columns through `setColumnWidth` function. Previous version forced the `setColumnWidth` function to provide a width for each column, after the change when a column width function returns `null` the default `width` is applied.

This PR aims to allow force widths on some columns (to avoid bugs [like this one](https://www.pivotaltracker.com/story/show/163790391))