### PR TITLE
Feature: selected options tooltip for multiselect dropdowns

### DIFF
--- a/src/components/multi-level-dropdown/components/selector.jsx
+++ b/src/components/multi-level-dropdown/components/selector.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactTooltip from 'react-tooltip';
 
 import Icon from 'components/icon';
 import cx from 'classnames';
@@ -23,6 +24,7 @@ const Selector = props => {
     innerRef,
     placeholder,
     defaultText,
+    selectedOptionsTooltip,
     values
   } = props;
   const showCloseIcon = clearable && isArray(values) && values.length > 0;
@@ -41,12 +43,20 @@ const Selector = props => {
     </button>
   );
 
+  const getSelectedOptionsTooltipText = () => {
+    if (!values || !isArray(values) || values.length < 2 || !selectedOptionsTooltip) return '';
+
+    return values.map(o => o.label).join(', ');
+  };
+
   return (
     <div
       ref={innerRef}
       className={styles.container}
     >
       <div
+        data-tip={getSelectedOptionsTooltipText()}
+        data-for="multiLevelDropdownOptionsTooltip"
         className={cx(styles.selector, {
           [styles.alignLeft]: arrowPosition,
           [styles.disabled]: disabled
@@ -55,17 +65,17 @@ const Selector = props => {
         {arrowPosition === 'left' && arrowDown}
         <span
           className={cx(styles.value, {
-            [styles.noValue]: !values || values.length === 0,
-            [styles.placeholder]:
+              [styles.noValue]: !values || values.length === 0,
+              [styles.placeholder]:
               !isOpen && !activeLabel && valuesSelectedLength === 0
           })}
         >
           {(isOpen && !searchable) || !isOpen ? (
-            activeLabel ||
-            valuesSelectedLabel ||
-            placeholder
+             activeLabel ||
+             valuesSelectedLabel ||
+             placeholder
           ) : (
-            ''
+             ''
           )}
         </span>
         <input {...inputProps()} />
@@ -82,6 +92,12 @@ const Selector = props => {
       </div>
       <div className={styles.menuArrow} />
       {children}
+      {selectedOptionsTooltip && (
+         <ReactTooltip
+           id="multiLevelDropdownOptionsTooltip"
+           effect="solid"
+         />
+      )}
     </div>
   );
 };
@@ -100,7 +116,8 @@ Selector.propTypes = {
   placeholder: PropTypes.string,
   innerRef: PropTypes.func,
   defaultText: PropTypes.shape({ selected: PropTypes.string }),
-  values: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
+  values: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  selectedOptionsTooltip: PropTypes.bool
 };
 
 Selector.defaultProps = {
@@ -117,7 +134,8 @@ Selector.defaultProps = {
   placeholder: undefined,
   innerRef: undefined,
   defaultText: { selected: 'selected' },
-  values: []
+  values: [],
+  selectedOptionsTooltip: true
 };
 
 export default Selector;

--- a/src/components/multi-level-dropdown/multi-level-dropdown-component.jsx
+++ b/src/components/multi-level-dropdown/multi-level-dropdown-component.jsx
@@ -36,7 +36,8 @@ class Dropdown extends PureComponent {
       disabled,
       handleOnChange,
       defaultText,
-      values
+      values,
+      selectedOptionsTooltip
     } = this.props;
     const dropdown = (
       <Downshift
@@ -60,6 +61,7 @@ class Dropdown extends PureComponent {
             placeholder={placeholder}
             values={values}
             defaultText={defaultText}
+            selectedOptionsTooltip={selectedOptionsTooltip}
             {...getRootProps({ refKey: 'innerRef' })}
           >
             <Menu
@@ -126,7 +128,8 @@ Dropdown.propTypes = {
   items: PropTypes.array,
   activeLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   highlightedIndex: PropTypes.number,
-  defaultText: PropTypes.shape({ selected: PropTypes.string})
+  defaultText: PropTypes.shape({ selected: PropTypes.string}),
+  selectedOptionsTooltip: PropTypes.bool
 };
 
 Dropdown.defaultProps = {
@@ -160,7 +163,8 @@ Dropdown.defaultProps = {
   activeLabel: undefined,
   highlightedIndex: undefined,
   defaultText: { selected: 'selected' },
-  values: []
+  values: [],
+  selectedOptionsTooltip: true
 };
 
 export default Dropdown;

--- a/src/components/multiselect/multiselect-styles.scss
+++ b/src/components/multiselect/multiselect-styles.scss
@@ -48,6 +48,7 @@
   z-index: 9;
 
   span {
+    pointer-events: unset;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Adding `selectedOptionsTooltip` property to `Multiselect` and `MultiLevelDropdown` components. It is shown only when 2 or more options are selected and it is enabled by default. It is possible to disable it by setting the property value to `false`.
![tooltip-multiselect-multileveldropdown](https://user-images.githubusercontent.com/1286444/55150970-8d82c500-514d-11e9-91f1-310328cb21b5.gif)


