### PR TITLE
multileveldropdown: optgroups

### DIFF
--- a/src/components/multi-level-dropdown/components/item.jsx
+++ b/src/components/multi-level-dropdown/components/item.jsx
@@ -9,21 +9,20 @@ import styles from '../multi-level-dropdown-styles.scss';
 
 const Item = props => {
   const {
-    index,
-    item,
-    showGroup,
-    highlightedIndex,
-    getItemProps,
-    toggleOpenGroup,
-    values,
     activeLabel,
+    extraIndent,
+    getItemProps,
+    highlightedIndex,
+    index,
+    isDisplayed,
+    item,
     noParentSelection,
-    theme
+    showGroup,
+    theme,
+    toggleOpenGroup,
+    values
   } = props;
   const { group, groupParent, label, active, hasActiveChild } = item;
-  const isDisplayed =
-    (!showGroup && !group) ||
-    (group === showGroup || groupParent === showGroup);
   const isGroupParentActive = groupParent && showGroup === groupParent;
   const isHighlighted =
     highlightedIndex === index ||
@@ -75,7 +74,10 @@ const Item = props => {
         {...getItemProps({
           item,
           index,
-          className: cx(styles.item, { [styles.highlight]: isHighlighted })
+          className: cx(styles.item, {
+            [styles.highlight]: isHighlighted,
+            [styles.extraIndent]: extraIndent
+          })
         })}
         {...parentClickProp}
       >
@@ -98,7 +100,9 @@ Item.propTypes = {
   values: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   activeLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   theme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  noParentSelection: PropTypes.bool
+  noParentSelection: PropTypes.bool,
+  isDisplayed: PropTypes.bool,
+  extraIndent: PropTypes.bool
 };
 
 Item.defaultProps = {
@@ -109,7 +113,9 @@ Item.defaultProps = {
   values: undefined,
   activeLabel: undefined,
   noParentSelection: false,
-  theme: undefined
+  theme: undefined,
+  isDisplayed: true,
+  extraIndent: false
 };
 
 export default Item;

--- a/src/components/multi-level-dropdown/components/menu.jsx
+++ b/src/components/multi-level-dropdown/components/menu.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import groupBy from 'lodash/groupBy';
 
 import Item from './item';
+import OptGroup from './optgroup';
 import styles from '../multi-level-dropdown-styles.scss';
 
 const Menu = props => {
@@ -19,34 +21,79 @@ const Menu = props => {
     noItemsFound,
     toggleOpenGroup,
     noParentSelection,
-    theme
+    theme,
+    optGroups
   } = props;
 
-  return !isOpen ? null : (
-    <div className={cx(styles.menu, theme.menu)}>
-      {items && items.length ? (
-        items.map((item, index) => (
-          <Item
-            key={`${item.slug}${item.id}${item.label}`}
-            index={index}
-            item={item}
-            showGroup={showGroup}
-            highlightedIndex={highlightedIndex}
-            getItemProps={getItemProps}
-            toggleOpenGroup={toggleOpenGroup}
-            optionsAction={optionsAction}
-            optionsActionKey={optionsActionKey}
-            activeLabel={activeLabel}
-            noParentSelection={noParentSelection}
-            theme={theme}
-            values={values}
-          />
-        ))
-      ) : (
+  const isItemDisplayed = ({ group, groupParent }) =>
+    (!showGroup && !group) ||
+    (group === showGroup || groupParent === showGroup);
+
+  // we must use it like that
+  let itemIndex = 0;
+
+  const renderItems = (itms, extraIndent = false) =>
+    itms && itms.map((item) => (
+      <Item
+        key={`${item.slug}${item.id}${item.label}`}
+        /* eslint-disable-next-line */
+        index={itemIndex++}
+        item={item}
+        isDisplayed={isItemDisplayed(item)}
+        extraIndent={extraIndent}
+        showGroup={showGroup}
+        highlightedIndex={highlightedIndex}
+        getItemProps={getItemProps}
+        toggleOpenGroup={toggleOpenGroup}
+        optionsAction={optionsAction}
+        optionsActionKey={optionsActionKey}
+        activeLabel={activeLabel}
+        noParentSelection={noParentSelection}
+        theme={theme}
+        values={values}
+      />
+    ))
+
+  const groupByOptGroup = groupBy(items, 'optGroup');
+  const withGroups = optGroups && !!optGroups.length;
+
+  const renderOptGroup = (group) => {
+    const itms = groupByOptGroup[group.groupId];
+    if (!itms || !itms.length) return null;
+    const notCurrentParent = (item) => !(showGroup === item.groupParent);
+    const isOptGroupVisible = itms.filter(notCurrentParent).some(isItemDisplayed);
+    return (
+      <React.Fragment key={group.groupId}>
+        {isOptGroupVisible && <OptGroup label={group.title} />}
+        {renderItems(itms, true)}
+      </React.Fragment>
+    );
+  }
+
+  const renderMenu = () => {
+    if (!items || !items.length) {
+      return (
         <div className={cx(styles.item, styles.notFound)}>
           {noItemsFound || 'No results found'}
         </div>
-      )}
+      )
+    }
+    if (withGroups) {
+      return (
+        <React.Fragment>
+          {optGroups.map(renderOptGroup)}
+          {renderItems(groupByOptGroup.undefined)}
+        </React.Fragment>
+      )
+    }
+    return renderItems(items);
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={cx(styles.menu, theme.menu)}>
+      {renderMenu()}
     </div>
   );
 };
@@ -57,6 +104,7 @@ Menu.propTypes = {
   theme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   activeLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   items: PropTypes.array,
+  optGroups: PropTypes.array,
   showGroup: PropTypes.string,
   getItemProps: PropTypes.func,
   highlightedIndex: PropTypes.number,
@@ -73,6 +121,7 @@ Menu.defaultProps = {
   theme: undefined,
   activeLabel: undefined,
   items: undefined,
+  optGroups: undefined,
   showGroup: undefined,
   getItemProps: undefined,
   highlightedIndex: undefined,

--- a/src/components/multi-level-dropdown/components/optgroup.jsx
+++ b/src/components/multi-level-dropdown/components/optgroup.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import cx from 'classnames';
+
+import styles from '../multi-level-dropdown-styles.scss';
+
+const OptGroup = props => {
+  const { label } = props;
+
+  return (
+    <div
+      className={cx(styles.itemWrapper, styles.show)}
+    >
+      <div
+        className={cx(styles.item, styles.optGroup)}
+      >
+        {label}
+      </div>
+    </div>
+  );
+};
+
+OptGroup.propTypes = {
+  label: PropTypes.string
+};
+
+OptGroup.defaultProps = {
+  label: undefined
+};
+
+export default OptGroup;

--- a/src/components/multi-level-dropdown/multi-level-dropdown-component.jsx
+++ b/src/components/multi-level-dropdown/multi-level-dropdown-component.jsx
@@ -29,6 +29,7 @@ class Dropdown extends PureComponent {
       isOpen,
       showGroup,
       items,
+      optGroups,
       activeLabel,
       highlightedIndex,
       noParentSelection,
@@ -68,6 +69,7 @@ class Dropdown extends PureComponent {
               isOpen={isOpen}
               activeLabel={activeLabel}
               items={items}
+              optGroups={optGroups}
               showGroup={showGroup}
               getItemProps={getItemProps}
               highlightedIndex={highlightedIndex}
@@ -126,6 +128,7 @@ Dropdown.propTypes = {
   buildInputProps: PropTypes.func,
   checkModalClosing: PropTypes.func,
   items: PropTypes.array,
+  optGroups: PropTypes.array,
   activeLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   highlightedIndex: PropTypes.number,
   defaultText: PropTypes.shape({ selected: PropTypes.string}),

--- a/src/components/multi-level-dropdown/multi-level-dropdown-styles.scss
+++ b/src/components/multi-level-dropdown/multi-level-dropdown-styles.scss
@@ -180,6 +180,10 @@ $dd-height: 45px;
     padding: rem(12px) rem(10px);
     border-bottom: 1px solid $border-color;
     overflow: hidden;
+
+    &.extraIndent {
+      padding-left: rem(20px);
+    }
   }
 
   .infoButton {
@@ -255,4 +259,12 @@ $dd-height: 45px;
     overflow: initial;
     transition: margin-left 0.2s ease-in-out;
   }
+}
+
+.optGroup {
+  color: $theme-color-light;
+  padding: 12px 10px;
+  text-transform: uppercase;
+  font-size: $font-size-s;
+  font-weight: $font-weight-bold;
 }

--- a/src/components/multi-level-dropdown/multi-level-dropdown.md
+++ b/src/components/multi-level-dropdown/multi-level-dropdown.md
@@ -89,3 +89,44 @@ const onValueChange = (selected) => {
   </MultiLevelDropdown>
 </div>
 ```
+
+Multiselect with option groups
+
+```js
+initialState = {
+  selected: [],
+  data:[
+    { label: 'Fruits', value: 'Fruits' , groupParent: 'Fruits', optGroup: 'yummy'},
+    { label: 'Apple', value: 'Apple' , group: 'Fruits'},
+    { label: 'Mango', value: 'Mango' , group: 'Fruits'},
+    { label: 'Banana', value: 'Banana ', group: 'Fruits'},
+    { label: 'Vegetables', value: 'Vegetables', groupParent: 'Vegetables', optGroup: 'not_so_much'},
+    { label: 'Pepper', value: 'Pepper', group: 'Vegetables'}
+  ],
+  optGroups: [{
+    title: 'Yummy',
+    groupId: 'yummy'
+  }, {
+    title: 'Not so much',
+    groupId: 'not_so_much'
+  }]
+}
+const onValueChange = (selected) => {
+  setState({ selected })
+}
+
+<div style={{ width: '200px'}}>
+  <MultiLevelDropdown
+    label="Multiple food selector"
+    options={state.data}
+    optGroups={state.optGroups}
+    values={state.selected}
+    onChange={onValueChange}
+    placeholder={'Select a fruit'}
+    clearable
+    searchable
+    multiselect
+  >
+  </MultiLevelDropdown>
+</div>
+```

--- a/src/components/multiselect/multiselect.md
+++ b/src/components/multiselect/multiselect.md
@@ -23,3 +23,39 @@ const onValueChange = (selected) => {
 </Multiselect>
 </div>
 ```
+
+Multiselect with sections/option groups
+
+```js
+initialState = {
+  selected: [],
+  data:[
+    { label: 'Apple', value: 'Apple', groupId: 'fruits' },
+    { label: 'Mango', value: 'Mango', groupdId: 'fruits' },
+    { label: 'Banana', value: 'Banana', groupId: 'fruits' },
+    { label: 'ReallyLongFruitNameWhichIDontRememberRighNow', value: 'Temporarily Unknown fruit', groupId: 'others'},
+    { label: 'Vaccinium ovatum Evergreen Huckleberry', value: 'Evergreen Huckleberry', groupId: 'others'}
+  ],
+  groups: [{
+    groupId: 'fruits',
+    title: 'Fruits'
+  }, {
+    groupId: 'others',
+    title: 'Others'
+  }]
+}
+const onValueChange = (selected) => {
+  setState({ selected })
+}
+
+<div style={{ width: '200px'}}>
+  <Multiselect
+    options={state.data}
+    groups={state.groups}
+    values={state.selected}
+    onValueChange={onValueChange}
+    placeholder={'Select a fruit'}
+  >
+</Multiselect>
+</div>
+```


### PR DESCRIPTION
Adding optgroups/sections to MultiLevelDropdown. Unfortunately, `group` name is taken by feature that creates multiple levels so I picked industry standard's name `optGroup` for this feature.

![optgroups](https://user-images.githubusercontent.com/1286444/55563642-98fa6100-56f6-11e9-9f85-5fc834f9e794.gif)
