### PR TITLE
Enable HTML parsing for Accordion component

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'react-collapse';
 import cx from 'classnames';
+import ReactMarkdown from 'react-markdown/with-html';
+
 import Icon from '../icon/icon';
 
 import dropdownArrow from './assets/dropdown-arrow.svg';
@@ -55,9 +57,7 @@ class Accordion extends PureComponent {
                   >
                     <div className={styles.layout}>
                       <div className={cx(styles.title, theme.title)}>
-                        <span>
-                          {title}
-                        </span>
+                        <ReactMarkdown source={title} escapeHtml={false} />
                         <Icon
                           icon={dropdownArrow}
                           theme={{


### PR DESCRIPTION
This PR replaces regular span tag with ReactMarkdown component and enables parsing HTML in Accordion component. (according to this [basecamp thread](https://basecamp.com/1756858/projects/15229632/todos/384159865))
![Screenshot from 2019-04-05 11 56 39](https://user-images.githubusercontent.com/15097138/55623102-e8459d80-5799-11e9-9fde-841ee11629d2.png)
