### PR TITLE
MultiLevelDropdown: fixing searchable and clearing active label

### DIFF
--- a/src/components/multi-level-dropdown/components/item.jsx
+++ b/src/components/multi-level-dropdown/components/item.jsx
@@ -9,7 +9,6 @@ import styles from '../multi-level-dropdown-styles.scss';
 
 const Item = props => {
   const {
-    activeLabel,
     extraIndent,
     getItemProps,
     highlightedIndex,
@@ -19,16 +18,13 @@ const Item = props => {
     noParentSelection,
     showGroup,
     theme,
-    toggleOpenGroup,
-    values
+    toggleOpenGroup
   } = props;
   const { group, groupParent, label, active, hasActiveChild } = item;
   const isGroupParentActive = groupParent && showGroup === groupParent;
   const isHighlighted =
     highlightedIndex === index ||
-    activeLabel === label ||
-    (groupParent && groupParent === showGroup) ||
-    (groupParent && values && groupParent === values.group);
+    (groupParent && groupParent === showGroup)
   const showToChildrenArrow =
     groupParent && showGroup !== groupParent && isDisplayed;
   const parentClickProp =
@@ -97,8 +93,6 @@ Item.propTypes = {
   highlightedIndex: PropTypes.number,
   getItemProps: PropTypes.func.isRequired,
   toggleOpenGroup: PropTypes.func.isRequired,
-  values: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-  activeLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   theme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   noParentSelection: PropTypes.bool,
   isDisplayed: PropTypes.bool,
@@ -110,8 +104,6 @@ Item.defaultProps = {
   item: undefined,
   showGroup: undefined,
   highlightedIndex: undefined,
-  values: undefined,
-  activeLabel: undefined,
   noParentSelection: false,
   theme: undefined,
   isDisplayed: true,

--- a/src/components/multi-level-dropdown/components/menu.jsx
+++ b/src/components/multi-level-dropdown/components/menu.jsx
@@ -10,8 +10,6 @@ import styles from '../multi-level-dropdown-styles.scss';
 const Menu = props => {
   const {
     isOpen,
-    values,
-    activeLabel,
     items,
     showGroup,
     getItemProps,
@@ -47,10 +45,8 @@ const Menu = props => {
         toggleOpenGroup={toggleOpenGroup}
         optionsAction={optionsAction}
         optionsActionKey={optionsActionKey}
-        activeLabel={activeLabel}
         noParentSelection={noParentSelection}
         theme={theme}
-        values={values}
       />
     ))
 
@@ -100,9 +96,7 @@ const Menu = props => {
 
 Menu.propTypes = {
   isOpen: PropTypes.bool,
-  values: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   theme: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  activeLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   items: PropTypes.array,
   optGroups: PropTypes.array,
   showGroup: PropTypes.string,
@@ -117,9 +111,7 @@ Menu.propTypes = {
 
 Menu.defaultProps = {
   isOpen: false,
-  values: [],
   theme: undefined,
-  activeLabel: undefined,
   items: undefined,
   optGroups: undefined,
   showGroup: undefined,

--- a/src/components/multi-level-dropdown/components/selector.jsx
+++ b/src/components/multi-level-dropdown/components/selector.jsx
@@ -4,7 +4,6 @@ import ReactTooltip from 'react-tooltip';
 
 import Icon from 'components/icon';
 import cx from 'classnames';
-import isArray from 'lodash/isArray';
 import arrowDownIcon from '../assets/dropdown-arrow.svg';
 import closeIcon from '../assets/close.svg';
 import styles from '../multi-level-dropdown-styles.scss';
@@ -16,7 +15,6 @@ const Selector = props => {
     arrowPosition,
     onSelectorClick,
     clearable,
-    activeLabel,
     searchable,
     inputProps,
     handleClearSelection,
@@ -27,12 +25,13 @@ const Selector = props => {
     selectedOptionsTooltip,
     values
   } = props;
-  const showCloseIcon = clearable && isArray(values) && values.length > 0;
+  const showCloseIcon = clearable && values.length > 0;
   const showDownArrow = arrowPosition !== 'left' && !disabled;
   const valuesSelectedLength = values.length;
   const valuesSelectedLabel = valuesSelectedLength === 1
                            ? values[0].label
-                           : valuesSelectedLength && `${valuesSelectedLength} ${defaultText.selected}`;
+                            : valuesSelectedLength && `${valuesSelectedLength} ${defaultText.selected}`;
+
   const arrowDown = (
     <button
       className={styles.arrowBtn}
@@ -44,7 +43,7 @@ const Selector = props => {
   );
 
   const getSelectedOptionsTooltipText = () => {
-    if (!values || !isArray(values) || values.length < 2 || !selectedOptionsTooltip) return '';
+    if (!values || values.length < 2 || !selectedOptionsTooltip) return '';
 
     return values.map(o => o.label).join(', ');
   };
@@ -67,11 +66,10 @@ const Selector = props => {
           className={cx(styles.value, {
               [styles.noValue]: !values || values.length === 0,
               [styles.placeholder]:
-              !isOpen && !activeLabel && valuesSelectedLength === 0
+              !isOpen && valuesSelectedLength === 0
           })}
         >
           {(isOpen && !searchable) || !isOpen ? (
-             activeLabel ||
              valuesSelectedLabel ||
              placeholder
           ) : (
@@ -109,14 +107,13 @@ Selector.propTypes = {
   arrowPosition: PropTypes.string,
   onSelectorClick: PropTypes.func,
   clearable: PropTypes.bool,
-  activeLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   searchable: PropTypes.bool,
   inputProps: PropTypes.func,
   handleClearSelection: PropTypes.func,
   placeholder: PropTypes.string,
   innerRef: PropTypes.func,
   defaultText: PropTypes.shape({ selected: PropTypes.string }),
-  values: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  values: PropTypes.array,
   selectedOptionsTooltip: PropTypes.bool
 };
 
@@ -127,7 +124,6 @@ Selector.defaultProps = {
   arrowPosition: undefined,
   onSelectorClick: undefined,
   clearable: false,
-  activeLabel: undefined,
   searchable: false,
   inputProps: undefined,
   handleClearSelection: undefined,

--- a/src/components/multi-level-dropdown/multi-level-dropdown-component.jsx
+++ b/src/components/multi-level-dropdown/multi-level-dropdown-component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import castArray from 'lodash/castArray';
 
 import Downshift from 'downshift';
 import cx from 'classnames';
@@ -30,7 +31,6 @@ class Dropdown extends PureComponent {
       showGroup,
       items,
       optGroups,
-      activeLabel,
       highlightedIndex,
       noParentSelection,
       placeholder,
@@ -40,6 +40,7 @@ class Dropdown extends PureComponent {
       values,
       selectedOptionsTooltip
     } = this.props;
+    const arrayValues = castArray(values).filter(x => x);
     const dropdown = (
       <Downshift
         itemToString={i => i && i.label}
@@ -54,20 +55,18 @@ class Dropdown extends PureComponent {
             arrowPosition={arrowPosition}
             onSelectorClick={onSelectorClick}
             clearable={clearable}
-            activeLabel={activeLabel}
             searchable={searchable}
             inputProps={() => buildInputProps(getInputProps)}
             handleClearSelection={() => handleClearSelection()}
             disabled={disabled}
             placeholder={placeholder}
-            values={values}
+            values={arrayValues}
             defaultText={defaultText}
             selectedOptionsTooltip={selectedOptionsTooltip}
             {...getRootProps({ refKey: 'innerRef' })}
           >
             <Menu
               isOpen={isOpen}
-              activeLabel={activeLabel}
               items={items}
               optGroups={optGroups}
               showGroup={showGroup}
@@ -129,7 +128,6 @@ Dropdown.propTypes = {
   checkModalClosing: PropTypes.func,
   items: PropTypes.array,
   optGroups: PropTypes.array,
-  activeLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   highlightedIndex: PropTypes.number,
   defaultText: PropTypes.shape({ selected: PropTypes.string}),
   selectedOptionsTooltip: PropTypes.bool
@@ -163,7 +161,6 @@ Dropdown.defaultProps = {
   buildInputProps: undefined,
   checkModalClosing: undefined,
   items: undefined,
-  activeLabel: undefined,
   highlightedIndex: undefined,
   defaultText: { selected: 'selected' },
   values: [],

--- a/src/components/multi-level-dropdown/multi-level-dropdown.js
+++ b/src/components/multi-level-dropdown/multi-level-dropdown.js
@@ -17,8 +17,7 @@ class MultiLevelDropdown extends PureComponent {
       inputValue: '',
       isOpen: false,
       showGroup: '',
-      highlightedIndex: 0,
-      activeLabel: undefined
+      highlightedIndex: 0
     };
   }
 
@@ -90,16 +89,6 @@ class MultiLevelDropdown extends PureComponent {
     onChange(selectedItems);
   };
 
-  updateActiveLabel = (selectedItem, clear) => {
-    const { values, multiselect } = this.props;
-    if (clear) return this.setState({ activeLabel: null });
-
-    const activeLabel = multiselect
-      ? values && values.length === 1 && values[0].label || null
-      : selectedItem;
-    return this.setState({ activeLabel });
-  };
-
   handleStateChange = (changes, downshiftStateAndHelpers) => {
     const { multiselect } = this.props;
     if (!changes || !downshiftStateAndHelpers.isOpen) return;
@@ -107,7 +96,7 @@ class MultiLevelDropdown extends PureComponent {
     if (changes.type === Downshift.stateChangeTypes.blurInput) return;
 
     if (changes.type === Downshift.stateChangeTypes.mouseUp) {
-      this.setState({ isOpen: false });
+      this.setState({ isOpen: false, inputValue: '' });
     } else {
       if (changes.inputValue || changes.inputValue === '') {
         if (
@@ -131,7 +120,6 @@ class MultiLevelDropdown extends PureComponent {
 
       if (changes.type === EVENT_TYPES.clickItem) {
         this.setState({ inputValue: '' });
-        this.updateActiveLabel(changes.inputValue);
       }
     }
   };
@@ -139,7 +127,6 @@ class MultiLevelDropdown extends PureComponent {
   handleClearSelection = () => {
     const { onChange } = this.props;
     onChange([]);
-    this.updateActiveLabel('', true);
     this.setState({ isOpen: false, showGroup: '', inputValue: '' });
   };
 
@@ -186,13 +173,7 @@ class MultiLevelDropdown extends PureComponent {
   };
 
   render() {
-    const {
-      isOpen,
-      showGroup,
-      inputValue,
-      highlightedIndex,
-      activeLabel
-    } = this.state;
+    const { isOpen, showGroup, inputValue, highlightedIndex } = this.state;
     return createElement(Component, {
       ...this.props,
       isOpen,
@@ -206,8 +187,7 @@ class MultiLevelDropdown extends PureComponent {
       buildInputProps: this.buildInputProps,
       toggleOpenGroup: this.toggleOpenGroup,
       handleOnChange: this.handleOnChange,
-      items: this.getGroupedItems(),
-      activeLabel
+      items: this.getGroupedItems()
     });
   }
 }


### PR DESCRIPTION
Two MultiLevelDropdown fixes

- searchable issue

before:
![mld_searchable_issue](https://user-images.githubusercontent.com/1286444/56314719-180b8280-6156-11e9-9d31-df3b599fdad9.gif)
after:
![mld_searchable_issue_fixed](https://user-images.githubusercontent.com/1286444/56314725-1e016380-6156-11e9-8b8a-1b698e129670.gif)

- clearing selected label when only one item selected and we want to clear selection providing empty table to `values` prop

before:
![mld_label_issue](https://user-images.githubusercontent.com/1286444/56314933-c0214b80-6156-11e9-8656-30ff6ebc04cb.gif)

after:
![mld_label_issue_fix](https://user-images.githubusercontent.com/1286444/56314943-c57e9600-6156-11e9-9dea-826c041f5897.gif)


