### PR TITLE
fix multilevel dropdown - parent elements without items should appear…

### DIFF
--- a/src/components/multi-level-dropdown/multi-level-dropdown-component.jsx
+++ b/src/components/multi-level-dropdown/multi-level-dropdown-component.jsx
@@ -9,6 +9,12 @@ import Selector from './components/selector';
 import Menu from './components/menu';
 import styles from './multi-level-dropdown-styles.scss';
 
+const nullifyGroupParentsWithoutElements = (items) =>
+  items.map((item) => ({
+    ...item,
+    groupParent: items.some(i => i.group === item.groupParent) ? item.groupParent : null
+  }));
+
 class Dropdown extends PureComponent {
   render() {
     const {
@@ -41,6 +47,7 @@ class Dropdown extends PureComponent {
       selectedOptionsTooltip
     } = this.props;
     const arrayValues = castArray(values).filter(x => x);
+    const menuItems = nullifyGroupParentsWithoutElements(items);
     const dropdown = (
       <Downshift
         itemToString={i => i && i.label}
@@ -67,7 +74,7 @@ class Dropdown extends PureComponent {
           >
             <Menu
               isOpen={isOpen}
-              items={items}
+              items={menuItems}
               optGroups={optGroups}
               showGroup={showGroup}
               getItemProps={getItemProps}

--- a/src/components/multi-level-dropdown/multi-level-dropdown.md
+++ b/src/components/multi-level-dropdown/multi-level-dropdown.md
@@ -7,7 +7,8 @@ initialState = {
     { label: 'Mango', value: 'Mango' , group: 'Fruits'},
     { label: 'Banana', value: 'Banana ', group: 'Fruits'},
     { label: 'Vegetables', value: 'Vegetables', groupParent: 'Vegetables'},
-    { label: 'Pepper', value: 'Pepper', group: 'Vegetables'}
+    { label: 'Pepper', value: 'Pepper', group: 'Vegetables'},
+    { label: 'Sweets', value: 'Empty', groupParent: 'Sweets'}
   ]
 }
 const onValueChange = (selected) => {


### PR DESCRIPTION
Fixing Multileveldropdown parent without element. When option which is indicated as a `groupParent` actually does not have any corresponding children then we should treat it as a normal option, without `>`.