### PR TITLE
Enable passing y-axis scale prop

### DIFF
--- a/src/components/charts/chart-composed/chart-composed.js
+++ b/src/components/charts/chart-composed/chart-composed.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import has from 'lodash/has';
+import get from 'lodash/get';
 import {
   XAxis,
   YAxis,
@@ -59,15 +59,9 @@ class ChartComposed extends PureComponent {
       customTooltip,
       getCustomYLabelFormat
     } = this.props;
-    const unit = showUnit &&
-      config &&
-      has(config, 'axes.yLeft.unit') &&
-      config.axes.yLeft.unit ||
-      null;
-    const suffix = config &&
-      has(config, 'axes.yLeft.suffix') &&
-      config.axes.yLeft.suffix ||
-      null;
+    const unit = showUnit && get(config, 'axes.yLeft.unit', null);
+    const suffix = get(config, 'axes.yLeft.suffix', null);
+    const yAxisScale = get(config, 'axes.yLeft.scale', 'auto');
     const hasDataOptions = !loading && dataOptions;
 
     return (
@@ -92,7 +86,7 @@ class ChartComposed extends PureComponent {
             <YAxis
               axisLine={false}
               tickLine={false}
-              scale="linear"
+              scale={yAxisScale}
               type="number"
               tick={
                 customYAxisTick ||
@@ -165,7 +159,8 @@ ChartComposed.propTypes = {
         name: PropTypes.string,
         unit: PropTypes.string,
         format: PropTypes.string,
-        suffix: PropTypes.string
+        suffix: PropTypes.string,
+        scale: PropTypes.string
       })
     })
   }),

--- a/src/components/charts/chart/chart.js
+++ b/src/components/charts/chart/chart.js
@@ -137,7 +137,8 @@ Chart.propTypes = {
         name: PropTypes.string,
         unit: PropTypes.string,
         format: PropTypes.string,
-        suffix: PropTypes.string
+        suffix: PropTypes.string,
+        scale: PropTypes.string
       })
     }),
     /** In barchart add same stackId attribute to each column object that you want to stack */

--- a/src/components/charts/line/line.js
+++ b/src/components/charts/line/line.js
@@ -80,6 +80,7 @@ class ChartLine extends PureComponent {
     const { activePoint, tooltipVisibility } = this.state;
     const unit = showUnit && get(config, 'axes.yLeft.unit', null);
     const suffix = get(config, 'axes.yLeft.suffix', null);
+    const yAxisScale = get(config, 'axes.yLeft.scale', 'auto');
     const lineState = { projectedData, data, config };
     const dataMaxMin = getDataMaxMin(lineState);
     const domain = projectedData ? getDomain(lineState) : customDomain;
@@ -118,7 +119,7 @@ class ChartLine extends PureComponent {
           <YAxis
             axisLine={false}
             tickLine={false}
-            scale="linear"
+            scale={yAxisScale}
             type="number"
             tick={
               customYAxisTick ||


### PR DESCRIPTION
This PR enables passing y-axis scale prop to line- and composed- chart. I've changed the default value of `scale` prop from `linear` to `auto`, so now, after updating version of CWC in our country project, it should show 0 on y-axis for each line/composed chart as default. If we would like to set different type of scale, we can pass `scale` prop in the config object (`config>axes>yLeft>scale`):
[RECHARTS DOCUMENTATION source](http://recharts.org/en-US/api/YAxis#scale) | [PIVOTAL](https://www.pivotaltracker.com/story/show/165491338)

![Screenshot from 2019-04-26 13 55 56](https://user-images.githubusercontent.com/15097138/56809160-1d8a5c00-682b-11e9-9659-f1ae903ad82b.png)

