### PR TITLE
fixing line chart custom domain

### DIFF
--- a/src/components/charts/line/line.js
+++ b/src/components/charts/line/line.js
@@ -83,7 +83,8 @@ class ChartLine extends PureComponent {
     const yAxisScale = get(config, 'axes.yLeft.scale', 'auto');
     const lineState = { projectedData, data, config };
     const dataMaxMin = getDataMaxMin(lineState);
-    const domain = projectedData ? getDomain(lineState) : customDomain;
+    const projectedDataAvailable = !!get(projectedData, 'length');
+    const domain = projectedDataAvailable ? getDomain(lineState) : customDomain;
     const dataWithTotal = getDataWithTotal(lineState);
     const lastData = getMaxValue(getDataWithTotal(lineState));
     const xAxisScale = getDiscontinousScale(lineState) || 'time';


### PR DESCRIPTION
Fixing the custom domain for the line chart.

`projectedData` by default is an empty array so it was always computing its own domain.