### PR TITLE
Change max-heigh to 300px for dropdown, multiselect and multileveldropdown components

### DIFF
--- a/src/components/dropdown/dropdown-styles.scss
+++ b/src/components/dropdown/dropdown-styles.scss
@@ -101,3 +101,9 @@
 .white {
   fill: #fff;
 }
+
+.dropdown :global {
+  .dropdown-menu {
+    max-height: 300px !important;
+  }
+}

--- a/src/components/multi-level-dropdown/multi-level-dropdown-styles.scss
+++ b/src/components/multi-level-dropdown/multi-level-dropdown-styles.scss
@@ -163,7 +163,7 @@ $dd-height: 45px;
   border: solid 1px $border-color;
   margin-top: -1px;
   z-index: 1;
-  max-height: rem(200px);
+  max-height: rem(300px);
   overflow-y: scroll;
   cursor: pointer;
   color: $dark-gray;

--- a/src/components/multiselect/multiselect-styles.scss
+++ b/src/components/multiselect/multiselect-styles.scss
@@ -65,6 +65,7 @@
   position: relative;
 
   .dropdown-menu {
+    max-height: 300px !important;
     .option-wrapper {
       padding: 12px 10px;
       position: relative;


### PR DESCRIPTION
This PR changes the max-height property of a dropdown menu to 300pxfor dropdown, multi-select and multilevel dropdown.