### PR TITLE
Add inner hover legend and modify tooltip offset

### DIFF
--- a/src/components/charts/pie-chart/customized-active-shape.jsx
+++ b/src/components/charts/pie-chart/customized-active-shape.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {
+  Sector
+} from 'recharts';
+import styles from './pie-chart-styles.scss';
+
+const CustomizedActiveShape = props => {
+  const {
+    cx,
+    cy,
+    innerRadius,
+    outerRadius,
+    startAngle,
+    endAngle,
+    fill,
+    percent,
+    theme
+  } = props;
+  return (
+    <g>
+      <Sector
+        cx={cx}
+        cy={cy}
+        innerRadius={innerRadius - 3}
+        outerRadius={outerRadius + 3}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        fill={fill}
+      />
+      <text
+        x={cx}
+        y={cy}
+        dy={10}
+        dx={2}
+        textAnchor="middle"
+        className={classnames(styles.innerHoverLabel, theme.innerHoverLabel)}
+      >
+        {`${(percent * 100).toFixed(0)}%`}
+      </text>
+    </g>
+  );
+};
+
+CustomizedActiveShape.propTypes = {
+  cx: PropTypes.number.isRequired,
+  cy: PropTypes.number.isRequired,
+  percent: PropTypes.number.isRequired,
+  innerRadius: PropTypes.number.isRequired,
+  outerRadius: PropTypes.number.isRequired,
+  startAngle: PropTypes.number.isRequired,
+  endAngle: PropTypes.number.isRequired,
+  fill: PropTypes.string.isRequired,
+  theme: PropTypes.shape()
+};
+
+CustomizedActiveShape.defaultProps = {
+  theme: undefined
+};
+
+export default CustomizedActiveShape;

--- a/src/components/charts/pie-chart/customized-label.jsx
+++ b/src/components/charts/pie-chart/customized-label.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const RADIAN = Math.PI / 180;
+const CustomizedLabel = (
+  { cx, cy, midAngle, innerRadius, outerRadius, percent },
+  { labelPositionRatio, hideLabel },
+  theme
+) => {
+  const radius =
+    innerRadius + (outerRadius - innerRadius) * (labelPositionRatio || 0.6);
+  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+  return !hideLabel ? (
+    <text
+      x={x}
+      y={y}
+      fill="white"
+      textAnchor={x > cx ? 'start' : 'end'}
+      dominantBaseline="central"
+      className={theme.label}
+    >
+      {`${(percent * 100).toFixed(0)}%`}
+    </text>
+  ) : null;
+};
+
+CustomizedLabel.propTypes = {
+  cx: PropTypes.number.isRequired,
+  cy: PropTypes.number.isRequired,
+  midAngle: PropTypes.number.isRequired,
+  innerRadius: PropTypes.number.isRequired,
+  outerRadius: PropTypes.number.isRequired,
+  percent: PropTypes.number.isRequired
+};
+
+export default CustomizedLabel;

--- a/src/components/charts/pie-chart/pie-chart-styles.scss
+++ b/src/components/charts/pie-chart/pie-chart-styles.scss
@@ -8,3 +8,7 @@
 .legend {
   opacity: 1;
 }
+
+.innerHoverLabel {
+  font-size: 2rem;
+}

--- a/src/components/charts/pie-chart/pie-chart.js
+++ b/src/components/charts/pie-chart/pie-chart.js
@@ -69,12 +69,35 @@ class PieChart extends PureComponent {
                     ))}
                 </Pie>
                 )) : (
-                  <Pie data={data} dataKey="value" fill={config.theme && config.theme.fill} label={content => CustomizedLabel(content, config, theme)} labelLine={false} activeShape={config.innerHoverLabel ? props => <CustomizedActiveShape innerHoverLabel={config.innerHoverLabel} theme={theme} {...props} /> : undefined} activeIndex={activeIndex} onMouseEnter={onPieEnter} isAnimationActive={config.animation || false} legendType="circle" innerRadius={config.innerRadius} outerRadius={config.outerRadius} cx={config.cx} cy={config.cy}>
+                  <Pie
+                    data={data}
+                    dataKey="value"
+                    fill={config.theme && config.theme.fill}
+                    label={content => CustomizedLabel(content, config, theme)}
+                    labelLine={false}
+                    activeShape={config.innerHoverLabel ?
+                      props => (
+                        <CustomizedActiveShape
+                          innerHoverLabel={config.innerHoverLabel}
+                          theme={theme}
+                          {...props}
+                        />
+                      ) : undefined
+                    }
+                    activeIndex={activeIndex}
+                    onMouseEnter={onPieEnter}
+                    isAnimationActive={config.animation || false}
+                    legendType="circle"
+                    innerRadius={config.innerRadius}
+                    outerRadius={config.outerRadius}
+                    cx={config.cx}
+                    cy={config.cy}
+                  >
                     {data.map(d => (
                       <Cell key={d.name} fill={getColor(d, config)} />
-                  ))}
+                    ))}
                   </Pie>
-)
+                )
             }
           </RechartsPieChart>
         </ResponsiveContainer>
@@ -83,23 +106,22 @@ class PieChart extends PureComponent {
           <div
             className={classnames(styles.legend, theme.legend)}
             style={{
-                  marginLeft: width / (config.legendPositionRatio || 4.75)
-                }}
+              marginLeft: width / (config.legendPositionRatio || 4.75)
+            }}
           >
             {Object
-                  .keys(config.theme)
-                  .map(q => (
-                    <Tag
-                      theme={theme.tag || simpleTagTheme}
-                      key={config.theme[q].label}
-                      canRemove={false}
-                      label={config.theme[q].label}
-                      color={config.theme[q].stroke}
-                    />
-                  ))}
+              .keys(config.theme)
+              .map(q => (
+                <Tag
+                  theme={theme.tag || simpleTagTheme}
+                  key={config.theme[q].label}
+                  canRemove={false}
+                  label={config.theme[q].label}
+                  color={config.theme[q].stroke}
+                />
+              ))}
           </div>
-            )
-        }
+        )}
       </div>
     );
   }

--- a/src/components/charts/pie-chart/pie-chart.md
+++ b/src/components/charts/pie-chart/pie-chart.md
@@ -194,3 +194,55 @@ const config = {
   config={config}
 />
 ```
+
+Example with animated pie chart, with inner hover label and extended hovered sector
+```js
+const width = 400;
+
+const data = [
+  { name: 'groupA', value: 400 },
+  { name: 'groupB', value: 300 },
+  { name: 'groupC', value: 300 },
+  { name: 'groupD', value: 200 },
+  { name: 'groupE', value: 278 },
+  { name: 'groupF', value: 189 }
+];
+
+const config = {
+  tooltip: {
+    groupA: { label: 'Group A' },
+    groupB: { label: 'Group B' },
+    groupC: { label: 'Group C' },
+    groupD: { label: 'Group D' },
+    groupE: { label: 'Group E' },
+    groupF: { label: 'Group F' },
+  },
+  animation: true,
+  axes: {
+    yLeft: {
+      unit: 'MtCO2e',
+      label: '2010'
+    }
+  },
+  theme: { // Color of the slices is in the stroke attribute:
+    // fill: '#f5b335', // Optional -just if monochrome
+    groupA: { label: 'Group A', stroke: 'red' },
+    groupB: { label: 'Group B', stroke: 'blue' },
+    groupC: { label: 'Group C', stroke: 'teal' },
+    groupD: { label: 'Group D', stroke: 'orange' },
+    groupE: { label: 'Group E', stroke: 'maroon' },
+    groupF: { label: 'Group F', stroke: 'fuchsia' },
+  },
+  innerRadius: 50,
+  innerHoverLabel: true,
+  outerRadius: 80,
+  hideLabel: true,
+  hideLegend: true
+};
+
+<PieChart
+  data={data}
+  width={width}
+  config={config}
+/>
+```


### PR DESCRIPTION
Add new pie example that has:

- Inner label on hover
- Changed radius of sector on hover
- Fix default props
- Change offset when we have the inner label so that the tooltip doesn't cover the centered label
- The label can be styled with a theme

![image](https://user-images.githubusercontent.com/9701591/69152800-6793a180-0add-11ea-925b-af1647918421.png)
