### PR TITLE
Fix default columns change

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -55,9 +55,16 @@ class Table extends PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { data } = this.props;
+    const { data, defaultColumns } = this.props;
     if (nextProps.data !== data) {
       this.setState({ data: nextProps.data });
+    }
+    if (nextProps.defaultColumns !== defaultColumns) {
+      const allColumns = Object.keys(get(data, '[0]', {}));
+      const columns = defaultColumns.length ? defaultColumns : allColumns;
+      this.setState({
+        activeColumns: columns.map(d => ({ label: d, value: d }))
+      });
     }
   }
 

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -33,6 +33,11 @@ const data = require('./data.json');
 const tableTheme = require('./table-theme.scss');
 
 const defaultColumns = ["name", "definition", "very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_header_label", "unit", "composite_name"];
+
+initialState = {
+  defaultColumns
+}
+
 const ellipsisColumns = ["composite_name"];
 const firstColumnHeaders = ["composite_name", "name"];
 const narrowColumns = ['definition']
@@ -41,20 +46,34 @@ const setColumnWidth = column => {
   return null
 }
 
-<Table
-  data={data}
-  hasColumnSelect
-  defaultColumns={defaultColumns}
-  ellipsisColumns={ellipsisColumns}
-  firstColumnHeaders={firstColumnHeaders}
-  emptyValueLabel={'Not specified'}
-  horizontalScroll
-  parseMarkdown
-  dynamicRowsHeight={true}
-  titleLinks={data.map(c => [{columnName: "link", url: "self", label: "View more"}])}
-  hiddenColumnHeaderLabels={['link']}
-  setColumnWidth={setColumnWidth}
-  theme={tableTheme}
-/>
+const toggleDefaultColumns = () => {
+  const newDefaultColumns = ["name", "definition", "unit", "percentages"];
+  if (state.defaultColumns.length === defaultColumns.length) {
+    setState({ defaultColumns: newDefaultColumns })
+  } else {
+    setState({ defaultColumns })
+  }
+}
+
+<>
+  <button onClick={toggleDefaultColumns}>
+    Change default columns
+  </button>
+  <Table
+    data={data}
+    hasColumnSelect
+    defaultColumns={state.defaultColumns}
+    ellipsisColumns={ellipsisColumns}
+    firstColumnHeaders={firstColumnHeaders}
+    emptyValueLabel={'Not specified'}
+    horizontalScroll
+    parseMarkdown
+    dynamicRowsHeight={true}
+    titleLinks={data.map(c => [{columnName: "link", url: "self", label: "View more"}])}
+    hiddenColumnHeaderLabels={['link']}
+    setColumnWidth={setColumnWidth}
+    theme={tableTheme}
+  />
+</>
 ```
 


### PR DESCRIPTION
This PR fixes a bug that was preventing the table to change when we passed different default columns

The second example of the table has a 'Change default columns' button that will simulate this different new prop

![image](https://user-images.githubusercontent.com/9701591/70257051-e64d3780-1789-11ea-8b52-4fc994fecdc7.png)
