### PR TITLE
Add customInnerHoverLabel prop with example

### DIFF
--- a/src/components/charts/pie-chart/customized-active-shape.jsx
+++ b/src/components/charts/pie-chart/customized-active-shape.jsx
@@ -16,7 +16,8 @@ const CustomizedActiveShape = props => {
     endAngle,
     fill,
     percent,
-    theme
+    theme,
+    customInnerHoverLabel
   } = props;
   return (
     <g>
@@ -29,16 +30,22 @@ const CustomizedActiveShape = props => {
         endAngle={endAngle}
         fill={fill}
       />
-      <text
-        x={cx}
-        y={cy}
-        dy={10}
-        dx={2}
-        textAnchor="middle"
-        className={classnames(styles.innerHoverLabel, theme.innerHoverLabel)}
-      >
-        {`${(percent * 100).toFixed(0)}%`}
-      </text>
+      {customInnerHoverLabel ?
+        customInnerHoverLabel({ x: cx, y: cy, value: percent }) :
+        (
+          <text
+            x={cx}
+            y={cy}
+            dy={10}
+            dx={2}
+            textAnchor="middle"
+            className={classnames(styles.innerHoverLabel, theme.innerHoverLabel)}
+          >
+          (
+            {`${(percent * 100).toFixed(0)}%`}
+          </text>
+        )
+      }
     </g>
   );
 };
@@ -52,11 +59,13 @@ CustomizedActiveShape.propTypes = {
   startAngle: PropTypes.number.isRequired,
   endAngle: PropTypes.number.isRequired,
   fill: PropTypes.string.isRequired,
-  theme: PropTypes.shape()
+  theme: PropTypes.shape(),
+  customInnerHoverLabel: PropTypes.node
 };
 
 CustomizedActiveShape.defaultProps = {
-  theme: undefined
+  theme: undefined,
+  customInnerHoverLabel: undefined
 };
 
 export default CustomizedActiveShape;

--- a/src/components/charts/pie-chart/customized-label.jsx
+++ b/src/components/charts/pie-chart/customized-label.jsx
@@ -7,12 +7,12 @@ const CustomizedLabel = (
   { labelPositionRatio, hideLabel },
   theme
 ) => {
+  if (hideLabel) return null;
   const radius =
     innerRadius + (outerRadius - innerRadius) * (labelPositionRatio || 0.6);
   const x = cx + radius * Math.cos(-midAngle * RADIAN);
   const y = cy + radius * Math.sin(-midAngle * RADIAN);
-
-  return !hideLabel ? (
+  return (
     <text
       x={x}
       y={y}
@@ -23,7 +23,7 @@ const CustomizedLabel = (
     >
       {`${(percent * 100).toFixed(0)}%`}
     </text>
-  ) : null;
+  );
 };
 
 CustomizedLabel.propTypes = {
@@ -32,7 +32,7 @@ CustomizedLabel.propTypes = {
   midAngle: PropTypes.number.isRequired,
   innerRadius: PropTypes.number.isRequired,
   outerRadius: PropTypes.number.isRequired,
-  percent: PropTypes.number.isRequired
+  percent: PropTypes.number.isRequired,
 };
 
 export default CustomizedLabel;

--- a/src/components/charts/pie-chart/pie-chart-theme.scss
+++ b/src/components/charts/pie-chart/pie-chart-theme.scss
@@ -1,0 +1,5 @@
+@import '~styles/settings.scss';
+
+.innerHoverLabel {
+  font-size: 12px;
+}

--- a/src/components/charts/pie-chart/pie-chart.js
+++ b/src/components/charts/pie-chart/pie-chart.js
@@ -28,13 +28,22 @@ class PieChart extends PureComponent {
   }
 
   render() {
-    const { config, data, width, margin, customTooltip, theme } = this.props;
+    const {
+      config,
+      data,
+      width,
+      margin,
+      customTooltip,
+      theme,
+      customInnerHoverLabel
+    } = this.props;
     const { activeIndex } = this.state;
     const isMultilevelPieChart = !Array.isArray(data);
 
     const onPieEnter = (d, index) => {
       this.setState({ activeIndex: index });
     };
+
     return (
       <div className={classnames(styles.pieChart, theme.pieChart)}>
         <ResponsiveContainer width={width} aspect={4 / 3}>
@@ -61,7 +70,13 @@ class PieChart extends PureComponent {
                   outerRadius={config.radius[key].outerRadius}
                   innerRadius={config.radius[key].innerRadius}
                   fill={config.theme && config.theme.fill}
-                  label={content => CustomizedLabel(content, config, theme)}
+                  label={content =>
+                      CustomizedLabel(
+                        content,
+                        config,
+                        theme,
+                        customInnerHoverLabel
+                      )}
                   labelLine={false}
                   isAnimationActive={config.animation || false}
                   legendType="circle"
@@ -70,62 +85,39 @@ class PieChart extends PureComponent {
                 >
                   {data[key].map(d => (
                     <Cell key={d.name} fill={getColor(d, config)} />
-                  ))}
+                    ))}
                 </Pie>
-              )) : (
-                <Pie
-                  data={data}
-                  dataKey="value"
-                  fill={config.theme && config.theme.fill}
-                  label={content => CustomizedLabel(content, config, theme)}
-                  labelLine={false}
-                  activeShape={
-                    config.innerHoverLabel ? props => (
-                      <CustomizedActiveShape
-                        innerHoverLabel={config.innerHoverLabel}
-                        theme={theme}
-                        {...props}
-                      />
-                    ) : undefined
-                  }
-                  activeIndex={activeIndex}
-                  onMouseEnter={onPieEnter}
-                  isAnimationActive={config.animation || false}
-                  legendType="circle"
-                  innerRadius={config.innerRadius}
-                  outerRadius={config.outerRadius}
-                  cx={config.cx}
-                  cy={config.cy}
-                >
-                  {data.map(d => (
-                    <Cell key={d.name} fill={getColor(d, config)} />
+                )) : (
+                  <Pie data={data} dataKey="value" fill={config.theme && config.theme.fill} label={content => CustomizedLabel(content, config, theme)} labelLine={false} activeShape={config.innerHoverLabel ? props => <CustomizedActiveShape customInnerHoverLabel={customInnerHoverLabel} innerHoverLabel={config.innerHoverLabel} theme={theme} {...props} /> : undefined} activeIndex={activeIndex} onMouseEnter={onPieEnter} isAnimationActive={config.animation || false} legendType="circle" innerRadius={config.innerRadius} outerRadius={config.outerRadius} cx={config.cx} cy={config.cy}>
+                    {data.map(d => (
+                      <Cell key={d.name} fill={getColor(d, config)} />
                   ))}
-                </Pie>
-              )
+                  </Pie>
+)
             }
           </RechartsPieChart>
         </ResponsiveContainer>
         {
           !config.hideLegend && Object.keys(config.theme) && (
-            <div
-              className={classnames(styles.legend, theme.legend)}
-              style={{
-                marginLeft: width / (config.legendPositionRatio || 4.75)
-              }}
-            >
-              {Object
-                .keys(config.theme)
-                .map(q => (
-                  <Tag
-                    theme={theme.tag || simpleTagTheme}
-                    key={config.theme[q].label}
-                    canRemove={false}
-                    label={config.theme[q].label}
-                    color={config.theme[q].stroke}
-                  />
-                ))}
-            </div>
-          )
+          <div
+            className={classnames(styles.legend, theme.legend)}
+            style={{
+                  marginLeft: width / (config.legendPositionRatio || 4.75)
+                }}
+          >
+            {Object
+                  .keys(config.theme)
+                  .map(q => (
+                    <Tag
+                      theme={theme.tag || simpleTagTheme}
+                      key={config.theme[q].label}
+                      canRemove={false}
+                      label={config.theme[q].label}
+                      color={config.theme[q].stroke}
+                    />
+                  ))}
+          </div>
+            )
         }
       </div>
     );
@@ -173,6 +165,7 @@ PieChart.propTypes = {
     bottom: PropTypes.number
   }),
   customTooltip: PropTypes.node,
+  customInnerHoverLabel: PropTypes.node,
   theme: PropTypes.shape({
     pieChart: PropTypes.oneOfType([ PropTypes.shape(), PropTypes.string ]),
     legend: PropTypes.oneOfType([ PropTypes.shape(), PropTypes.string ]),
@@ -197,6 +190,7 @@ PieChart.defaultProps = {
   },
   data: [],
   customTooltip: null,
+  customInnerHoverLabel: null,
   theme: {}
 };
 

--- a/src/components/charts/pie-chart/pie-chart.md
+++ b/src/components/charts/pie-chart/pie-chart.md
@@ -197,6 +197,8 @@ const config = {
 
 Example with animated pie chart, with inner hover label and extended hovered sector
 ```js
+
+const theme = require('./pie-chart-theme.scss');
 const width = 400;
 
 const data = [
@@ -207,7 +209,33 @@ const data = [
   { name: 'groupE', value: 278 },
   { name: 'groupF', value: 189 }
 ];
-
+const customInnerHoverLabel = ({ x, y, value }) => (
+    <text
+      x={x}
+      y={y - 18}
+    >
+      <tspan
+        x={x}
+        textAnchor="middle"
+      >
+        {Math.round(value * 10) / 10} %
+      </tspan>
+      <tspan
+        x={x}
+        textAnchor="middle"
+        dy="20"
+      >
+        of global
+      </tspan>
+      <tspan
+        x={x}
+        textAnchor="middle"
+        dy="20"
+      >
+        emissions.
+      </tspan>
+    </text>
+  );
 const config = {
   tooltip: {
     groupA: { label: 'Group A' },
@@ -244,5 +272,7 @@ const config = {
   data={data}
   width={width}
   config={config}
+  customInnerHoverLabel={customInnerHoverLabel}
+  theme={theme}
 />
 ```


### PR DESCRIPTION
This PR allows for a custom label on the center of the pie chart this was needed on the CW flagship

![image](https://user-images.githubusercontent.com/9701591/73188301-f3036180-4122-11ea-856b-d7d4f6e66ea6.png)


