### PR TITLE
Add customCellRenderer function to table

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -185,7 +185,8 @@ class Table extends PureComponent {
       ellipsisColumns,
       dynamicRowsHeight,
       hiddenColumnHeaderLabels,
-      theme
+      theme,
+      customCellRenderer
     } = this.props;
     if (!data.length) return null;
     const hasColumnSelectedOptions = hasColumnSelect && columnsOptions;
@@ -297,10 +298,12 @@ class Table extends PureComponent {
                       dataKey={column}
                       flexGrow={0}
                       cellRenderer={cell =>
-                        cellRenderer({
-                          props: { ...this.props, titleLinks },
-                          cell
-                        })}
+                        customCellRenderer
+                          ? customCellRenderer(cell)
+                          : cellRenderer({
+                            props: { ...this.props, titleLinks },
+                            cell
+                          })}
                       {...this.columnWidthProps(column, data)}
                     />
                   ))}
@@ -348,6 +351,8 @@ Table.propTypes = {
   /** Array to order the column headers */
   // eslint-disable-next-line react/forbid-prop-types
   firstColumnHeaders: PropTypes.array,
+  /** Function that overrides the cell rendering */
+  customCellRenderer: PropTypes.func,
   /** Boolean value to calculate dynamic rows */
   dynamicRowsHeight: PropTypes.bool,
   /** Array of column header that dev do not want to display on header row */
@@ -398,6 +403,7 @@ Table.defaultProps = {
   dynamicRowsHeight: false,
   parseHtml: false,
   parseMarkdown: false,
+  customCellRenderer: undefined,
   theme: {}
 };
 

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -75,4 +75,25 @@ const toggleDefaultColumns = () => {
     theme={tableTheme}
   />
 </>
+
+```
+
+Table with custom Cell renderer
+
+```jsx
+const data = require('./data.json');
+const isNaN = require('lodash/isNaN');
+const iconDownload = require('../button-group/assets/download.svg').default;
+const iconInfo = require('../button-group/assets/info.svg').default;
+const defaultColumns = ["name", "percentages"];
+
+<Table
+  data={data}
+  defaultColumns={defaultColumns}
+  customCellRenderer={(cell) => isNaN(parseFloat(cell.cellData)) ? (
+    <Icon onClick={() => console.log('NaN clicked')} icon={iconDownload}></Icon>
+  ) : (
+    <Icon onClick={() => console.log('Number clicked')} icon={iconInfo}></Icon>
+  )}
+/>
 ```


### PR DESCRIPTION
Adds a customCellRenderer function that could be passed to the Table

![image](https://user-images.githubusercontent.com/9701591/73935282-74f04900-48e0-11ea-96ff-4ad75f1a04d0.png)
