### PR TITLE
Add minAngle to config

### DIFF
--- a/src/components/charts/pie-chart/pie-chart.js
+++ b/src/components/charts/pie-chart/pie-chart.js
@@ -80,6 +80,7 @@ class PieChart extends PureComponent {
                   labelLine={false}
                   isAnimationActive={config.animation || false}
                   legendType="circle"
+                  minAngle={config.minAngle}
                   cx={config.cx}
                   cy={config.cy}
                 >
@@ -88,7 +89,7 @@ class PieChart extends PureComponent {
                     ))}
                 </Pie>
                 )) : (
-                  <Pie data={data} dataKey="value" fill={config.theme && config.theme.fill} label={content => CustomizedLabel(content, config, theme)} labelLine={false} activeShape={config.innerHoverLabel ? props => <CustomizedActiveShape customInnerHoverLabel={customInnerHoverLabel} innerHoverLabel={config.innerHoverLabel} theme={theme} {...props} /> : undefined} activeIndex={activeIndex} onMouseEnter={onPieEnter} isAnimationActive={config.animation || false} legendType="circle" innerRadius={config.innerRadius} outerRadius={config.outerRadius} cx={config.cx} cy={config.cy}>
+                  <Pie data={data} dataKey="value" fill={config.theme && config.theme.fill} label={content => CustomizedLabel(content, config, theme)} labelLine={false} activeShape={config.innerHoverLabel ? props => <CustomizedActiveShape customInnerHoverLabel={customInnerHoverLabel} innerHoverLabel={config.innerHoverLabel} theme={theme} {...props} /> : undefined} activeIndex={activeIndex} onMouseEnter={onPieEnter} isAnimationActive={config.animation || false} legendType="circle" innerRadius={config.innerRadius} outerRadius={config.outerRadius} cx={config.cx} cy={config.cy} minAngle={config.minAngle}>
                     {data.map(d => (
                       <Cell key={d.name} fill={getColor(d, config)} />
                   ))}

--- a/src/components/charts/pie-chart/pie-chart.md
+++ b/src/components/charts/pie-chart/pie-chart.md
@@ -207,7 +207,7 @@ const data = [
   { name: 'groupC', value: 300 },
   { name: 'groupD', value: 200 },
   { name: 'groupE', value: 278 },
-  { name: 'groupF', value: 189 }
+  { name: 'groupF', value: 0.1 }
 ];
 const customInnerHoverLabel = ({ x, y, value }) => (
     <text
@@ -265,7 +265,8 @@ const config = {
   innerHoverLabel: { offset: 80 },
   outerRadius: 80,
   hideLabel: true,
-  hideLegend: true
+  hideLegend: true,
+  minAngle: 2
 };
 
 <PieChart


### PR DESCRIPTION
This is a minimal change that allows the minAngle prop to be specified in the config. This prop changes the minimal reference that we have in the chart even if the value could not be represented.

![image](https://user-images.githubusercontent.com/9701591/74163518-cc652080-4c22-11ea-946d-04bcc8241228.png)
