### PR TITLE
Fix calculation and add config

### DIFF
--- a/src/components/table/table-utils.js
+++ b/src/components/table/table-utils.js
@@ -57,44 +57,27 @@ export const getMeanLength = (columnWidthSamples, data, column) => {
   return aggregatedLenght / samples;
 };
 
-const getDatum = (dataD, index) => dataD[index];
+export const getDynamicRowHeight = (
+  rowData,
+  getColumnWidth,
+  dynamicRowsConfig
+) =>
+  {
+    const { fontWidth, fontSize, extraMargin, lineHeight } = dynamicRowsConfig;
+    const orderedColumnNames = _sortBy(
+      Object.keys(rowData),
+      key => String(rowData[key]).length
+    );
+    const greatestColumnName = orderedColumnNames[orderedColumnNames.length -
+      1];
+    const columnLength = getColumnWidth([ rowData ], greatestColumnName);
 
-const getLongestTextColumnName = (data, columnHeightSamples) => {
-  const columnsTextLengthSamples = [];
-  [ ...Array(columnHeightSamples).keys() ].forEach(n => {
-    const keys = data[n] && Object.keys(data[n]);
-    const columnsTextLength = {};
-    if (keys) {
-      keys.forEach(column => {
-        columnsTextLength[column] = data[n][column] && data[n][column].length;
-      });
+    const greatestColumnNameDatum = String(rowData[greatestColumnName]);
+    if (!greatestColumnNameDatum) {
+      return 120;
     }
-    columnsTextLengthSamples.push(columnsTextLength);
-  });
-
-  const aggregatedLength = {};
-  columnsTextLengthSamples.forEach(sample => {
-    Object.keys(sample).forEach(key => {
-      if (!aggregatedLength[key]) aggregatedLength[key] = 0;
-      if (sample[key]) aggregatedLength[key] += sample[key];
-      else aggregatedLength[key] += 0;
-    });
-  });
-  const greatestLength = Math.max(...Object.values(aggregatedLength));
-  const columnName = Object
-    .keys(aggregatedLength)
-    .find(column => aggregatedLength[column] === greatestLength);
-  return columnName;
-};
-
-export const getDynamicRowHeight = (data, columnHeightSamples, index) => {
-  const considerableMargin = 100;
-  const greatestColumnName = getLongestTextColumnName(
-    data,
-    columnHeightSamples
-  );
-
-  return getDatum(data, index)[greatestColumnName] &&
-    getDatum(data, index)[greatestColumnName].length / 3 + considerableMargin ||
-    120;
-};
+    const textColumnsNumber = greatestColumnNameDatum.length *
+      fontWidth /
+      columnLength;
+    return (textColumnsNumber + 1) * fontSize * lineHeight + extraMargin;
+  };

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -4,7 +4,7 @@ const data = require('./data.json');
 const defaultColumns = ["name", "definition", "unit", "composite_name", "percentages", "very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_header_label"];
 const ellipsisColumns = ["composite_name"];
 const firstColumnHeaders = ["composite_name", "name"];
-const narrowColumns = ['definition']
+const narrowColumns = ['unit', 'country', 'Date of LTS submission', 'composite_name', 'percentages', 'stackable', 'definition']
 const setColumnWidth = column => {
   if (narrowColumns.includes(column)) return 180;
   return 230
@@ -19,7 +19,8 @@ const setColumnWidth = column => {
   emptyValueLabel={'Not specified'}
   horizontalScroll
   parseMarkdown
-  dynamicRowsHeight={true}
+  dynamicRowsHeight
+  forceAllRowSamples
   titleLinks={data.map(c => [{ columnName: "name", url: c.link.name }])}
   hiddenColumnHeaderLabels={['link']}
   setColumnWidth={setColumnWidth}
@@ -42,11 +43,11 @@ initialState = {
 
 const ellipsisColumns = ['composite_name'];
 const firstColumnHeaders = ['composite_name', 'name'];
-const narrowColumns = ['country', 'Date of LTS submission']
+const narrowColumns = ['country', 'Date of LTS submission', 'composite_name', 'percentages', 'stackable']
 const wideColumns = ['Assessment of the impacts of changes in climate on long-lived infrastructure, land-use planning, (Current selection)', 'Co-benefits of mitigation actions for adaptation/resilience and vice versa (Current selection)']
 const setColumnWidth = column => {
   if (wideColumns.includes(column)) return 380;
-  if (narrowColumns.includes(column)) return 100;
+  if (narrowColumns.includes(column)) return 60;
   return 300
 }
 


### PR DESCRIPTION
This PR fixes the dynamic row height calculation. It picks each row individually instead of using a sample and calculates the row number taking into account the width and chars in each cell.

A new prop with a config has been added to tweak the numbers if needed. The default font-size is 14px

The only problem I found is the parsed HTML inside the cells that won't take into account the extra line breaks. We can use the extra margin for that.

![image](https://user-images.githubusercontent.com/9701591/80623534-9e85c000-8a4a-11ea-871a-79388a0e91e5.png)
