### PR TITLE
Add tableWidthOffset and fix missing constant

### DIFF
--- a/src/components/table/altered-table-theme.scss
+++ b/src/components/table/altered-table-theme.scss
@@ -1,0 +1,9 @@
+.headerRow {
+  > div { // header column
+    margin-right: 0 !important; // Due to the :global in styles
+  }
+}
+
+.column {
+  margin-right: 0 !important; // Due to the :global in styles
+}

--- a/src/components/table/table-utils.js
+++ b/src/components/table/table-utils.js
@@ -44,6 +44,7 @@ export const capitalizeFirstLetter = text =>
   `${text.charAt(0).toUpperCase()}${text.slice(1)}`;
 
 export const getMeanLength = (columnWidthSamples, data, column) => {
+  const STANDARD_COLUMN_WIDTH = 180;
   const sampleNumbersArray = [ ...Array(columnWidthSamples).keys() ];
   let samples = 0;
   let aggregatedLenght = 0;
@@ -53,7 +54,7 @@ export const getMeanLength = (columnWidthSamples, data, column) => {
       samples += 1;
     }
   });
-  if (samples < 1) return this.standardColumnWidth;
+  if (samples < 1) return STANDARD_COLUMN_WIDTH;
   return aggregatedLenght / samples;
 };
 

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -40,7 +40,6 @@ class Table extends PureComponent {
       shouldOverflow: false,
       titleLinks
     };
-    this.standardColumnWidth = 180;
     this.minColumnWidth = 80;
     this.maxColumnWidth = 300;
     this.lengthWidthRatio = 4;
@@ -83,10 +82,10 @@ class Table extends PureComponent {
     }
   }
 
-  getFullWidth = (data, columns, width) => {
+  getFullWidth = (data, columns, width, tableWidthOffset) => {
     const { setColumnWidth } = this.props;
-    const columnsLenght = columns.length;
-    if (columnsLenght === 1) return width;
+    const columnsLength = columns.length;
+    if (columnsLength === 1) return width;
     const totalWidth = columns.reduce(
       (acc, column) => {
         const columnWidth = setColumnWidth && setColumnWidth(column.label) ||
@@ -97,7 +96,7 @@ class Table extends PureComponent {
     );
     this.tableWrapperWidth = this.tableWrapper && this.tableWrapper.offsetWidth;
     this.setState({ shouldOverflow: totalWidth > this.tableWrapperWidth });
-    return totalWidth < width ? width : totalWidth;
+    return totalWidth < width ? width : totalWidth + tableWidthOffset;
   };
 
   handleSortChange = ({ sortBy, sortDirection }) => {
@@ -192,7 +191,8 @@ class Table extends PureComponent {
       hiddenColumnHeaderLabels,
       theme,
       customCellRenderer,
-      dynamicRowsConfig
+      dynamicRowsConfig,
+      tableWidthOffset
     } = this.props;
     if (!data.length) return null;
     const hasColumnSelectedOptions = hasColumnSelect && columnsOptions;
@@ -259,7 +259,12 @@ class Table extends PureComponent {
             {({ width }) => (
               <VirtualizedTable
                 className={styles.table}
-                width={this.getFullWidth(propsData, activeColumns, width)}
+                width={this.getFullWidth(
+                  propsData,
+                  activeColumns,
+                  width,
+                  tableWidthOffset
+                )}
                 height={tableHeight}
                 headerHeight={headerHeight}
                 rowClassName={this.rowClassName}
@@ -354,6 +359,8 @@ Table.propTypes = {
   tableHeight: PropTypes.number,
   /** Initial table header height */
   headerHeight: PropTypes.number,
+  /** Custom offset for the table width in special cases */
+  tableWidthOffset: PropTypes.number,
   /** Trim line to include ... */
   // eslint-disable-next-line react/forbid-prop-types
   ellipsisColumns: PropTypes.array,
@@ -378,7 +385,7 @@ Table.propTypes = {
   hiddenColumnHeaderLabels: PropTypes.arrayOf(PropTypes.string),
   /** Array of arrays of objects holding the properties of the columns that should have linkable content.
    * This prop is passed to `cell-renderer-component`
-   * exaple: __`titleLinks={data.map(c => [{columnName: "link", url: "self", label: "View more"}])}`__
+   * example: __`titleLinks={data.map(c => [{columnName: "link", url: "self", label: "View more"}])}`__
    */
   titleLinks: PropTypes.arrayOf(
     PropTypes.arrayOf(
@@ -413,8 +420,9 @@ Table.defaultProps = {
   headerHeight: 42,
   defaultColumns: [],
   hasColumnSelect: false,
-  setColumnWidth: null,
+  setColumnWidth: undefined,
   setRowsHeight: null,
+  tableWidthOffset: 0,
   ellipsisColumns: [],
   firstColumnHeaders: [],
   hiddenColumnHeaderLabels: [],

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -98,3 +98,21 @@ const defaultColumns = ["name", "percentages"];
   )}
 />
 ```
+
+Table with total width offset
+
+```jsx
+
+const data = require('./data.json');
+const tableTheme = require('./altered-table-theme.scss');
+const defaultColumns = ["name", "definition", "unit", "composite_name", "percentages", "stackable", "category","link", "subcategory"];
+
+<Table
+  data={data}
+  tableHeight={550}
+  defaultColumns={defaultColumns}
+  setColumnWidth={() => 115}
+  theme={tableTheme}
+  tableWidthOffset={-80}
+/>
+```


### PR DESCRIPTION
This PR adds a prop for the table component: tableWidthOffset. This prop helps to deal with situations in which we have extra space on the horizontal scroll table. We now can manually adjust this width to remove this space.

The extra width, in this case, is caused by some adjustments on that table theme and is fixed with the new prop

![image](https://user-images.githubusercontent.com/9701591/91966504-386bbb00-ed12-11ea-8a80-73e6983d53db.png)
